### PR TITLE
Feat(#like-view-count) 법안 좋아요 및 조회수 기능, 의원 좋아요 기능 추가 

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
@@ -22,15 +22,19 @@ public class BillInfoDto {
     private LocalDate proposeDate;
     private String summary;
     private String gptSummary;
+    private int viewCount;
+    private int billLikeCount;
 
 
-    public static BillInfoDto fromBill(Bill bill) {
+    public static BillInfoDto from(Bill bill) {
         return BillInfoDto.builder()
                 .billId(bill.getId())
                 .billName(bill.getBillName())
                 .proposeDate(bill.getProposeDate())
                 .summary(bill.getSummary())
                 .gptSummary(bill.getGptSummary())
+                .viewCount(bill.getViewCount())
+                .billLikeCount(bill.getLikeCount())
                 .build();
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillLikeResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillLikeResponse.java
@@ -1,0 +1,32 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.everyones.lawmaking.domain.entity.BillLike;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BillLikeResponse {
+
+    @NotNull
+    private long userId;
+
+    @NotNull
+    private String billId;
+
+    @NotNull
+    private boolean likeCheckd;
+
+
+    public static BillLikeResponse from(BillLike billLike) {
+        return BillLikeResponse.builder()
+                .billId(billLike.getBill().getId())
+                .userId(billLike.getUser().getId())
+                .likeCheckd(billLike.isLikeChecked())
+                .build();
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillViewCountResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillViewCountResponse.java
@@ -1,9 +1,8 @@
 package com.everyones.lawmaking.common.dto.response;
 
-import com.everyones.lawmaking.domain.entity.BillLike;
+import com.everyones.lawmaking.domain.entity.Bill;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,19 +11,16 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class BillLikeResponse {
-
-    @NotNull
+public class BillViewCountResponse {
     private String billId;
 
-    @NotNull
-    private boolean likeCheckd;
+    private int viewCount;
 
 
-    public static BillLikeResponse from(BillLike billLike) {
-        return BillLikeResponse.builder()
-                .billId(billLike.getBill().getId())
-                .likeCheckd(billLike.isLikeChecked())
+    public static BillViewCountResponse from(Bill bill) {
+        return BillViewCountResponse.builder()
+                .billId(bill.getId())
+                .viewCount(bill.getViewCount())
                 .build();
 
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
@@ -1,6 +1,6 @@
 package com.everyones.lawmaking.common.dto.response;
 
-import com.everyones.lawmaking.domain.entity.BillLike;
+import com.everyones.lawmaking.domain.entity.CongressManLike;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
@@ -12,20 +12,19 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class BillLikeResponse {
+public class CongressmanLikeResponse {
 
     @NotNull
-    private String billId;
+    private String congressmanId;
 
     @NotNull
-    private boolean likeCheckd;
+    private boolean likeChecked;
 
-
-    public static BillLikeResponse from(BillLike billLike) {
-        return BillLikeResponse.builder()
-                .billId(billLike.getBill().getId())
-                .likeCheckd(billLike.isLikeChecked())
+    public static CongressmanLikeResponse from(CongressManLike congressmanLike){
+        return CongressmanLikeResponse.builder()
+                .congressmanId(congressmanLike.getCongressMan().getId())
+                .likeChecked(congressmanLike.isLikeChecked())
                 .build();
-
     }
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
@@ -1,11 +1,14 @@
 package com.everyones.lawmaking.controller;
 
 import com.everyones.lawmaking.common.dto.BillDto;
+import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
 import com.everyones.lawmaking.common.dto.response.BillListResponse;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.BaseResponse;
+import com.everyones.lawmaking.global.auth.PrincipalDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +17,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
@@ -101,6 +107,35 @@ public class BillController {
             @PathVariable("bill_id") String billId) {
         var result = facade.getBillByBillId(billId);
         return BaseResponse.ok(result);
+
+    }
+
+    @Operation(summary = "법안 좋아요", description = "법안 좋아요 기능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    /*
+    TODO: patch와 post기능이 둘 다 있는데, Post로 정의하는 것이 맞는가에 대한 고민
+    like 관련을 따로 Controller를 파는게 맞는가에 대한 고민이 있다.
+    */
+    @PostMapping("/like")
+    public BaseResponse<BillLikeResponse> likeBill(
+            Authentication authentication,
+            @Parameter(example = "PRC_G2O3O1N2O1M1K1L5A0A8Z2Z2Y7W6X3")
+            @RequestParam("bill_id") String billId
+    ) {
+        var userDetails = (PrincipalDetails) authentication.getPrincipal();
+        var userId = userDetails.getUserId();
+        var result = facade.likeBill(userId, billId);
 
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
@@ -3,12 +3,12 @@ package com.everyones.lawmaking.controller;
 import com.everyones.lawmaking.common.dto.BillDto;
 import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
 import com.everyones.lawmaking.common.dto.response.BillListResponse;
+import com.everyones.lawmaking.common.dto.response.BillViewCountResponse;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.BaseResponse;
 import com.everyones.lawmaking.global.auth.PrincipalDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,9 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
@@ -110,6 +108,28 @@ public class BillController {
 
     }
 
+    @Operation(summary = "법안 조회수 증가", description = "법안 id로 조회수를 증가시킵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PatchMapping("/view_count")
+    public BaseResponse<BillViewCountResponse> updateViewCount(
+            @Parameter(example = "PRC_G2O3O1N2O1M1K1L5A0A8Z2Z2Y7W6X3")
+            @RequestParam("bill_id") String billId
+    ) {
+        var result = facade.updateViewCount(billId);
+        return BaseResponse.ok(result);
+    }
+
     @Operation(summary = "법안 좋아요", description = "법안 좋아요 기능")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -127,16 +147,20 @@ public class BillController {
     TODO: patch와 post기능이 둘 다 있는데, Post로 정의하는 것이 맞는가에 대한 고민
     like 관련을 따로 Controller를 파는게 맞는가에 대한 고민이 있다.
     */
-    @PostMapping("/like")
+    @PostMapping("/bookmark")
     public BaseResponse<BillLikeResponse> likeBill(
             Authentication authentication,
             @Parameter(example = "PRC_G2O3O1N2O1M1K1L5A0A8Z2Z2Y7W6X3")
-            @RequestParam("bill_id") String billId
+            @RequestParam("bill_id") String billId,
+            @Schema(type = "boolean", allowableValues = {"true", "false"})
+            @RequestParam("likeChecked") boolean likeChecked
+
     ) {
         var userDetails = (PrincipalDetails) authentication.getPrincipal();
         var userId = userDetails.getUserId();
-        var result = facade.likeBill(userId, billId);
+        var result = facade.likeBill(userId, billId, likeChecked);
 
+        return BaseResponse.ok(result);
     }
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -1,8 +1,11 @@
 package com.everyones.lawmaking.domain.entity;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -10,10 +13,11 @@ import java.util.List;
 
 
 @Entity
-@Getter
+@Data
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Bill {
     @Id
     @Column(name = "bill_id")
@@ -60,5 +64,11 @@ public class Bill {
 
     @Column(name = "bill_pdf_url")
     private String billPdfUrl; // PDF 파일의 경로 또는 식별자
+
+    @ColumnDefault("0")
+    private int viewCount;
+
+    @ColumnDefault("0")
+    private int likeCount;
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillBookmark.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillBookmark.java
@@ -1,5 +1,7 @@
 package com.everyones.lawmaking.domain.entity;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -9,6 +11,8 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Table(uniqueConstraints = @UniqueConstraint(name = "ix_bill_like_unique", columnNames = {"user_id", "bill_id"}))
 public class BillBookmark {
 
     @Id

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillLike.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillLike.java
@@ -10,6 +10,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(name = "ix_bill_like_unique", columnNames = {"user_id", "bill_id"}))
 public class BillLike {
 
     @Id

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -1,18 +1,22 @@
 package com.everyones.lawmaking.domain.entity;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
 @Entity
-@Getter
+@Data
 @Builder
 @ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Congressman {
     @Id
     @Column(name = "congressman_id")
@@ -52,4 +56,7 @@ public class Congressman {
 
     @Column(name = "congressman_image_url")
     private String congressmanImageUrl;
+
+    @ColumnDefault("0")
+    private int likeCount;
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
@@ -23,7 +23,6 @@ public class User extends BaseEntity  {
     @JoinColumn(name = "auth_info_id")
     private AuthInfo authInfo;
 
-
     @NotNull
     private String email;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -2,11 +2,10 @@ package com.everyones.lawmaking.facade;
 
 import com.everyones.lawmaking.common.dto.BillDto;
 import com.everyones.lawmaking.common.dto.CongressmanDto;
+import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
 import com.everyones.lawmaking.common.dto.response.BillListResponse;
 import com.everyones.lawmaking.common.dto.response.PartyDetailDto;
-import com.everyones.lawmaking.service.BillService;
-import com.everyones.lawmaking.service.CongressmanService;
-import com.everyones.lawmaking.service.PartyService;
+import com.everyones.lawmaking.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,6 +20,8 @@ public class Facade {
     private final PartyService partyService;
     private final BillService billService;
     private final CongressmanService congressmanService;
+    private final LikeService likeService;
+    private final UserService userService;
 
     public BillListResponse getBillsFromMainFeed(Pageable pageable) {
         return billService.getBillsByDefault(pageable);
@@ -59,6 +60,15 @@ public class Facade {
         return billService.getPublicBillsByParty(pageable, partyId);
     }
 
+
+    @Transactional
+    public BillLikeResponse likeBill(long userId, String billId) {
+        // 해당하는 userId와 billId가 있는 지 확인 없으면 하위 모듈에서 에러 발생
+        var bill = billService.getBillEntityById(billId);
+        var user = userService.getUserId(userId);
+        return likeService.likeBill(user, bill);
+
+    }
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -2,16 +2,12 @@ package com.everyones.lawmaking.facade;
 
 import com.everyones.lawmaking.common.dto.BillDto;
 import com.everyones.lawmaking.common.dto.CongressmanDto;
-import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
-import com.everyones.lawmaking.common.dto.response.BillListResponse;
-import com.everyones.lawmaking.common.dto.response.PartyDetailDto;
+import com.everyones.lawmaking.common.dto.response.*;
 import com.everyones.lawmaking.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,16 +19,24 @@ public class Facade {
     private final LikeService likeService;
     private final UserService userService;
 
+    // default로 메인피드에 띄울 법안 가져오기 현재 최신순으로 반환해줌.
     public BillListResponse getBillsFromMainFeed(Pageable pageable) {
         return billService.getBillsByDefault(pageable);
     }
 
+    // 법안의 처리 단계에 따라 법안 페이징해서 법안 반환
     public BillListResponse getBillsByStage(Pageable pageable, String stage) {
         return billService.getBillsByStage(pageable, stage);
     }
 
+    // 법안 아이디를 기준으로, 하나의 법안 상세 조회
     public BillDto getBillByBillId(String billId) {
         return billService.getBillWithDetail(billId);
+    }
+
+    // 법안 조회수 증가
+    public BillViewCountResponse updateViewCount(String billId) {
+        return billService.updateViewCount(billId);
     }
 
     // Congressman 대표 발의 가져오기
@@ -40,18 +44,22 @@ public class Facade {
         return billService.getBillInfoFromRepresentativeProposer(congressmanId, pageable);
     }
 
+    // Congressman 공동 발의 법안 가져오기
     public BillListResponse getBillsFromPublicProposer(String congressmanId, Pageable pageable) {
         return billService.getBillInfoFromPublicProposer(congressmanId, pageable);
     }
 
+    // 의원 상세 조회
     public CongressmanDto getCongressman(String congressmanId) {
         return congressmanService.getCongressman(congressmanId);
     }
 
+    // 정당 상세 조회
     public PartyDetailDto getPartyById(long partyId) {
         return partyService.getPartyById(partyId);
     }
 
+    //
     public BillListResponse getRepresentativeBillsByParty(Pageable pageable, long partyId) {
         return billService.getRepresentativeBillsByParty(pageable, partyId);
     }
@@ -60,14 +68,21 @@ public class Facade {
         return billService.getPublicBillsByParty(pageable, partyId);
     }
 
-
-    @Transactional
-    public BillLikeResponse likeBill(long userId, String billId) {
+    // 법안 좋아요 기능
+    public BillLikeResponse likeBill(long userId, String billId, boolean likeChecked) {
         // 해당하는 userId와 billId가 있는 지 확인 없으면 하위 모듈에서 에러 발생
         var bill = billService.getBillEntityById(billId);
         var user = userService.getUserId(userId);
+        billService.updateBillLikeCount(bill, likeChecked);
         return likeService.likeBill(user, bill);
+    }
 
+    // 의원 좋아요 기능
+    public CongressmanLikeResponse likeCongressman(long userId, String congressmanId, boolean likeChecked) {
+        var user = userService.getUserId(userId);
+        var congressman = congressmanService.findCongressman(congressmanId);
+        congressmanService.updateCongressmanLikeCount(congressman, likeChecked);
+        return likeService.likeCongressman(user, congressman);
     }
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SwaggerConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SwaggerConfig.java
@@ -1,0 +1,44 @@
+package com.everyones.lawmaking.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    @Bean
+    public GroupedOpenApi allApi() {
+        return GroupedOpenApi.builder()
+                .group("All")
+                .pathsToMatch("/v1/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi apiNeededAuthorization() {
+        return GroupedOpenApi.builder()
+                .group("Authorization")
+                .pathsToMatch("/**/like**", "/**/bookmark**")
+                .build();
+    }
+
+
+
+    private Info apiInfo() {
+        return new Info()
+                .title("LawDigest V1 API")
+                .description("LawBag 명세 문서.")
+                .version("1.0.0");
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -1,0 +1,18 @@
+package com.everyones.lawmaking.repository;
+
+import com.everyones.lawmaking.domain.entity.BillLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
+
+    @Query("select bl from BillLike bl " +
+            "where bl.bill.id = :billId AND bl.user.id = :userId")
+    Optional<BillLike> findByIds(@Param("userId") long userId, @Param("billId") String billId);
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -13,6 +13,6 @@ public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
 
     @Query("select bl from BillLike bl " +
             "where bl.bill.id = :billId AND bl.user.id = :userId")
-    Optional<BillLike> findByIds(@Param("userId") long userId, @Param("billId") String billId);
+    Optional<BillLike> findByUserIdAndBillId(@Param("userId") long userId, @Param("billId") String billId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -1,0 +1,10 @@
+package com.everyones.lawmaking.repository;
+
+import com.everyones.lawmaking.domain.entity.CongressManLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CongressmanLikeRepository extends JpaRepository<CongressManLike, Long> {
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -2,9 +2,17 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.CongressManLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface CongressmanLikeRepository extends JpaRepository<CongressManLike, Long> {
+
+    @Query("SELECT cl FROM CongressManLike cl " +
+            "WHERE cl.user.id = :userId AND cl.congressMan.id = :congressmanId")
+    Optional<CongressManLike> findByUserIdAndCongressmanId(@Param("userId")long userId, @Param("congressmanId")String congressmanId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -9,7 +9,6 @@ import com.everyones.lawmaking.common.dto.response.PaginationResponse;
 import com.everyones.lawmaking.domain.entity.Bill;
 import com.everyones.lawmaking.global.CustomException;
 import com.everyones.lawmaking.global.ResponseCode;
-import com.everyones.lawmaking.repository.BillProposerRepository;
 import com.everyones.lawmaking.repository.BillRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,18 +16,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-
-
 @RequiredArgsConstructor
 @Service
 @Slf4j
 @Transactional(readOnly = true)
 public class BillService {
     private final BillRepository billRepository;
-    private final BillProposerRepository billProposerRepository;
+
+    public Bill getBillEntityById(String billId) {
+        return billRepository.findById(billId)
+                .orElseThrow(() -> new CustomException(ResponseCode.INTERNAL_SERVER_ERROR));
+    }
 
     public BillListResponse getBillsByDefault(Pageable pageable) {
         // 메인피드에서 Bill 정보 페이지네이션으로 가져오기
@@ -108,7 +106,7 @@ public class BillService {
         }
         var billIdList = billSlice.stream()
                 .map(Bill::getId)
-                .collect(Collectors.toList());
+                .toList();
 
 
         var billList = billRepository.findBillInfoByIdList(billIdList);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
@@ -18,10 +18,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class CongressmanService {
     private final CongressmanRepository congressmanRepository;
 
-    public CongressmanDto getCongressman(String congressmanId) {
-        Congressman congressman = congressmanRepository.findByIdWithParty(congressmanId)
+    public Congressman findCongressman(String congressmanId) {
+        return congressmanRepository.findByIdWithParty(congressmanId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 의원이 존재하지 않습니다."));
+    }
+
+    public CongressmanDto getCongressman(String congressmanId) {
+        var congressman = findCongressman(congressmanId);
         return CongressmanDto.fromCongressman(congressman);
+    }
+
+    @Transactional
+    public void updateCongressmanLikeCount(Congressman congressman, boolean likeChecked) {
+        var likeCount = likeChecked ? congressman.getLikeCount() + 1 : congressman.getLikeCount() - 1;
+        congressman.setLikeCount(likeCount);
+        congressmanRepository.save(congressman);
     }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -1,0 +1,55 @@
+package com.everyones.lawmaking.service;
+
+import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
+import com.everyones.lawmaking.domain.entity.Bill;
+import com.everyones.lawmaking.domain.entity.BillLike;
+import com.everyones.lawmaking.domain.entity.User;
+import com.everyones.lawmaking.global.CustomException;
+import com.everyones.lawmaking.global.ResponseCode;
+import com.everyones.lawmaking.repository.BillLikeRepository;
+import com.everyones.lawmaking.repository.CongressmanLikeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class LikeService {
+    private final BillLikeRepository billLikeRepository;
+    private final CongressmanLikeRepository congressmanLikeRepository;
+
+    // TODO: 반환형 점검
+    public BillLikeResponse likeBill(User user, Bill bill) {
+        var billLike = billLikeRepository.findByIds(user.getId(), bill.getId());
+        var modifiedBillLike = billLike.isPresent() ? updateBillLike(billLike.get()) : createBillLike(user, bill);
+
+        return modifiedBillLike;
+    }
+
+
+    private BillLikeResponse createBillLike(User user, Bill bill) {
+        var billLike = BillLike.builder()
+                .bill(bill)
+                .user(user)
+                .likeChecked(true)
+                .build();
+        billLikeRepository.save(billLike);
+
+        return BillLikeResponse.from(billLike);
+    }
+
+
+    private BillLikeResponse updateBillLike(BillLike billLike) {
+        var updatedBillLike = BillLike.builder()
+                .id(billLike.getId())
+                .bill(billLike.getBill())
+                .user(billLike.getUser())
+                .likeChecked(!billLike.isLikeChecked())
+                .build();
+        billLikeRepository.save(updatedBillLike);
+        return BillLikeResponse.from(updatedBillLike);
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -1,11 +1,8 @@
 package com.everyones.lawmaking.service;
 
 import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
-import com.everyones.lawmaking.domain.entity.Bill;
-import com.everyones.lawmaking.domain.entity.BillLike;
-import com.everyones.lawmaking.domain.entity.User;
-import com.everyones.lawmaking.global.CustomException;
-import com.everyones.lawmaking.global.ResponseCode;
+import com.everyones.lawmaking.common.dto.response.CongressmanLikeResponse;
+import com.everyones.lawmaking.domain.entity.*;
 import com.everyones.lawmaking.repository.BillLikeRepository;
 import com.everyones.lawmaking.repository.CongressmanLikeRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +18,41 @@ public class LikeService {
     private final BillLikeRepository billLikeRepository;
     private final CongressmanLikeRepository congressmanLikeRepository;
 
-    // TODO: 반환형 점검
+    @Transactional
     public BillLikeResponse likeBill(User user, Bill bill) {
-        var billLike = billLikeRepository.findByIds(user.getId(), bill.getId());
-        var modifiedBillLike = billLike.isPresent() ? updateBillLike(billLike.get()) : createBillLike(user, bill);
+        var billLike = billLikeRepository.findByUserIdAndBillId(user.getId(), bill.getId());
 
-        return modifiedBillLike;
+        return billLike.isPresent() ? updateBillLike(billLike.get()) : createBillLike(user, bill);
     }
 
+    @Transactional
+    public CongressmanLikeResponse likeCongressman(User user, Congressman congressman) {
+        var congressmanLike = congressmanLikeRepository.findByUserIdAndCongressmanId(user.getId(), congressman.getId());
+
+        return congressmanLike.isPresent() ? updateCongressmanLike(congressmanLike.get()) : createCongressmanLike(user ,congressman);
+    }
+
+    private CongressmanLikeResponse createCongressmanLike(User user, Congressman congressman) {
+        var congressmanLike = CongressManLike.builder()
+                .congressMan(congressman)
+                .user(user)
+                .likeChecked(true)
+                .build();
+        congressmanLikeRepository.save(congressmanLike);
+
+        return CongressmanLikeResponse.from(congressmanLike);
+    }
+
+    private CongressmanLikeResponse updateCongressmanLike(CongressManLike congressmanLike) {
+        var updatedCongressmanLike = CongressManLike.builder()
+                .id(congressmanLike.getId())
+                .congressMan(congressmanLike.getCongressMan())
+                .user(congressmanLike.getUser())
+                .likeChecked(!congressmanLike.isLikeChecked())
+                .build();
+        congressmanLikeRepository.save(updatedCongressmanLike);
+        return CongressmanLikeResponse.from(updatedCongressmanLike);
+    }
 
     private BillLikeResponse createBillLike(User user, Bill bill) {
         var billLike = BillLike.builder()
@@ -52,4 +76,6 @@ public class LikeService {
         billLikeRepository.save(updatedBillLike);
         return BillLikeResponse.from(updatedBillLike);
     }
+
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
@@ -1,0 +1,20 @@
+package com.everyones.lawmaking.service;
+
+import com.everyones.lawmaking.domain.entity.User;
+import com.everyones.lawmaking.global.CustomException;
+import com.everyones.lawmaking.global.ResponseCode;
+import com.everyones.lawmaking.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User getUserId(long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ResponseCode.INTERNAL_SERVER_ERROR));
+    }
+
+}


### PR DESCRIPTION
## 개요
법안 좋아요 및 조회수 기능, 의원 좋아요 기능 추가 

### 세부 사항
조회수, 좋아요 기능은 반정규화로 인해 동시성 문제를 고려해야 한다.
또한, 좋아요는 좋아요 테이블과 법안, 의원 테이블 사이에서의 정합성을 맞추는 것도 고려해야 한다.

현재 코드는 이를 고려하지 않은 코드이기 때문에, 추후 리팩토링으로 해당 사항 처리 해야함.
#78 에 적어 놓음.