### PR TITLE
MySQL 데이터 변환시 저장하는 bin log 캐치하고 매핑완료 (알림 기능)

### DIFF
--- a/lawmaking/build.gradle
+++ b/lawmaking/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // mysql bin log connector
+    implementation group: 'com.zendesk', name: 'mysql-binlog-connector-java', version: '0.29.0'
+
+
+
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.hibernate:hibernate-validator:7.0.5.Final'

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
@@ -1,0 +1,318 @@
+package com.everyones.lawmaking.global.config;
+
+import com.everyones.lawmaking.global.internal.model.WatchedColumnEvent;
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.*;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Component
+@ConfigurationProperties(prefix = "binlog")
+public class TableEventListener {
+    /**
+     * DB host(ipv4)
+     */
+    @Value("${binlog.host}")
+    private String host;
+    /**
+     * DB port
+     */
+    @Value("${binlog.port}")
+    private int port;
+    /**
+     * DB username
+     */
+    @Value("${binlog.user}")
+    private String user;
+    /**
+     * DB password
+     */
+    @Value("${binlog.password}")
+    private String password;
+
+    @Value("${db-connection-pool.db-name}")
+    private String dbName;
+
+    private static final Set<EventType> recordedEventTypes = Set.of(EventType.EXT_WRITE_ROWS, EventType.EXT_UPDATE_ROWS, EventType.EXT_DELETE_ROWS, EventType.TABLE_MAP);
+    private static final Map<Long, TableMapInfo> relatedTableMapEvents = new HashMap<>();
+
+    //TODO : static 클래스 빈 객체로 생성해서 사용하기(리팩토링)
+    @Data
+    private static class TableMapInfo {
+        private TableMapEventData tableMapEventData;
+        private Set<Event> dmlEvents;
+    }
+    /**
+     * 테이블별 (컬럼네임,컬럼 인덱스) 정보 가져오는 메서드
+     * @return Map(테이블명, Map(컬럼명, 컬럼 인덱스))
+     */
+    Map<String, Map<String, Integer>> fetchColumnOrdersByTable() {
+        Map<String, Map<String, Integer>> columnOrdersByTable = new HashMap<>();
+
+        // 커넥션 풀 새로 만들어서 컬럼 이름 가져오기
+        try (Connection connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port, user, password)) {
+            // try with 구문 시작
+            // connection의 메타데이터를 가져와서
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet tableResultSet = metaData.getTables(dbName, "public", null, new String[]{"TABLE"})) {
+                // metaData의 테이블 정보를 가져옴
+                while (tableResultSet.next()) {
+                    // 테이블 이름을 tableName에 저장
+                    String tableName = tableResultSet.getString("TABLE_NAME").toLowerCase();
+
+                    // 컬럼 네임별 인덱스 저장할 해시맵 생성
+                    Map<String, Integer> columnOrders = new HashMap<>();
+
+                    // 해당 table의 컬럼 가져와서 try-with 구문 시작
+                    try (ResultSet columnResultSet = metaData.getColumns(dbName, "public", tableName, null)) {
+                        // 컬럼 이름과 컬럼 매칭 인덱스를 맵에 저장
+                        while (columnResultSet.next()) {
+                            columnOrders.put(columnResultSet.getString("COLUMN_NAME").toLowerCase(), columnResultSet.getInt("ORDINAL_POSITION") - 1);
+                        }
+                    }
+                    // 테이블 당 컬럼들의 네임과 인덱스를 저장한 해시맵을 put
+                    columnOrdersByTable.put(tableName, Collections.unmodifiableMap(columnOrders));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Collections.unmodifiableMap(columnOrdersByTable);
+    }
+
+
+    @Bean
+    BinaryLogClient binaryLogClient() throws IOException {
+        final Map<String, Map<String, Integer>> columnOrdersByTable = fetchColumnOrdersByTable();
+
+        final List<WatchedColumnEvent> watchedColumnEvents = List.of(
+                // 생성
+                // 팔로우한 의원의 법안 발의 알림 -> RepresentativeProposer 에서 새롭게 row가 생성이 되면 국회의원 id와 bill_id, 수정된 날짜 넘겨줌 (생성)
+                new WatchedColumnEvent(
+                        "rp_insert",
+                        "representativeproposer",
+                        null,
+                        WatchedColumnEvent.ColumnEventType.INSERT,
+                        List.of("congressman_id","bill_id")),
+
+                // 수정
+                // 스크랩한 법안 처리상태 변동 알림 -> Bill 에서 변동된 데이터중에 stage가 변경이 되었으면 발의한 의원과 법안 이름 stage, 수정된 날짜 넘겨줌
+                new WatchedColumnEvent(
+                        "bill_stage_update",
+                        "bill",
+                        "stage",
+                        WatchedColumnEvent.ColumnEventType.UPDATE,
+                        List.of("bill_id","stage","bill_name")),
+                // 정당별 상태 변동 -> Congressman 에서 변동된 데이터 중에 party_id가 변경이 되면 CongressMan의 이름과 pary_id, 수정된 날짜 넘겨줌
+                new WatchedColumnEvent(
+                        "congressman_party_update",
+                        "congressman",
+                        "party_id",
+                        WatchedColumnEvent.ColumnEventType.UPDATE,
+                        List.of("name","party_id"))
+        );
+
+        final List<String> watchedTableNames = watchedColumnEvents.stream().map(WatchedColumnEvent::getTableName).toList();
+
+        BinaryLogClient logClient = new BinaryLogClient(
+                host,
+                port,
+                user,
+                password);
+
+        // 받은 데이터를 BYTE 로 표현
+        EventDeserializer eventDeserializer = new EventDeserializer();
+        eventDeserializer.setCompatibilityMode(
+                EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG,
+                EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY
+        );
+
+        logClient.registerEventListener(event -> {
+            // 이벤트 타입에 따라서 Data가 없는 것도 있음.
+            // 따라서 바로 event.getData를 호출하는 것은 주의
+            final EventType eventType = event.getHeader().getEventType();
+            if (eventType == EventType.XID) {
+
+                // Operation에 따라서 before after 변화를 감지.
+                relatedTableMapEvents.forEach((_tableId, tableMapInfo) -> {
+                    // 여기서 매핑정보들 테이블id 와 before after 변화 감지해서 원하는 알림처리 메소드 호출
+                    final TableMapEventData tableMapEventData = tableMapInfo.getTableMapEventData();
+
+                    final String tableName = tableMapEventData.getTable().toLowerCase();
+                    // 이벤트 감지가 필요없는 테이블이면 스킵
+                    // tableName은 all 소문자로 옴
+                    if (!watchedTableNames.contains(tableName)) return;
+
+                    final Set<Event> dmlOperations = tableMapInfo.getDmlEvents();
+                    //TODO: 시간 순서대로 리스트를 받지 않는 문제가 있음 만약 수정 삭제 생성이 한 트랜잭션에서 여러 작업이 동시에 일어나는 경우 잘못된 알림이 발생할 경우가 있음.
+                    dmlOperations.forEach(e -> {
+                        final EventData data = e.getData();
+                        // 하나의 트랜잭션에는 여러개의 로우가 관여할 수 있음, 또한 하나의 Serializable 객체는 하나의 컬럼 값임.
+                        if (data instanceof WriteRowsEventData insertedData) {
+                            List<Serializable[]> rows = insertedData.getRows();
+
+                            // WriteRows에 관한 알림처리할 컬럼 인덱스 필터링
+                            // 알림 데이터로 필요한 (이벤트네임, 컬럼 인덱스)를 저장
+                            Map<String, List<Integer>> resultColumnsIndicesByEvent = watchedColumnEvents
+                                    .stream()
+                                    .filter(wce -> tableName.equalsIgnoreCase(wce.getTableName())
+                                                && wce.getEventType() == WatchedColumnEvent.ColumnEventType.INSERT)
+                                    .map(wce -> {
+                                        final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName, new HashMap<>());
+                                        return new AbstractMap.SimpleEntry<>(
+                                                wce.getEventName(),
+                                                wce.getResultColumnNames()
+                                                        .stream()
+                                                        .map(columnName ->
+                                                        columnOrdersForTable.getOrDefault(columnName.toLowerCase(), -1))
+                                                        .toList()
+
+                                        );
+                                    })
+                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                            // 이벤트 타입, 필터된 컬럼데이터
+                            List<Map<String, List<String>>> filteredValuesByRows = rows.stream()
+                                    .map(row -> {
+                                        final Map<String, List<String>> filteredValues = new HashMap<>();
+                                        resultColumnsIndicesByEvent.forEach((eventName, columnIndices) -> {
+                                            final List<String> values = new ArrayList<>();
+                                            columnIndices.stream().filter(index->index>=0).forEach((index) -> values.add(row[index].toString()));
+                                            filteredValues.put(eventName, Collections.unmodifiableList(values));
+                                        });
+                                        return Collections.unmodifiableMap(filteredValues);
+                                    })
+                                    .toList();
+
+
+                            // @TODO: 이제 테이블명과 변경된 로우 ID 매핑 후, 컬럼 값들을 파싱하고 처리하는 클래스에 넘겨주기
+                            // 필요한 테이블 : bill, CongressMan
+                            // 컬럼 : 의원이 새로운 법안을 발의함(bill의 bill_name), 의원이 새로 추가됨(name)
+                            // 알림 보내야할 테이블이면 bill_name 혹은 의원 이름을 추출해서 알림 메시지로 보내버림
+
+
+                            // @TODO: 데이터 삭제 알림 필요시 주석 해제
+                            //} else if (data instanceof DeleteRowsEventData) {
+                            //final DeleteRowsEventData insertedData = (DeleteRowsEventData) data;
+                        } else if (data instanceof UpdateRowsEventData changedData) {
+
+                            // @TODO: 이제 테이블명과 변경된 로우 ID 매핑 후, 컬럼 값들을 파싱하고 처리하는 클래스에 넘겨주기
+                            // 필요한 테이블 : bill, CongressMan
+                            // 컬럼 : 법안의 처리상태 변동(bill의 bill_name, stage), 의원의 정당 바뀜(이름, 바뀐정당)
+
+                            //List로 스트림 건 후 before after를 지정 컬럼으로 확인
+                            // 알림 이벤트 타입이랑 인덱스 추출
+                            Map<String, List<Integer>> resultColumnsIndicesByEvent = watchedColumnEvents
+                                    .stream()
+                                    .filter(wce -> tableName.equalsIgnoreCase(wce.getTableName())
+                                            && wce.getEventType() == WatchedColumnEvent.ColumnEventType.UPDATE)
+                                    .map(wce -> {
+                                        final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName, new HashMap<>());
+                                        return new AbstractMap.SimpleEntry<>(
+                                                wce.getEventName(),
+                                                Stream.concat(
+                                                        Stream.of(columnOrdersForTable.getOrDefault(wce.getColumnName().toLowerCase(), -1)),
+                                                        wce.getResultColumnNames()
+                                                            .stream()
+                                                            .map(columnName ->
+                                                                columnOrdersForTable.getOrDefault(columnName.toLowerCase(), -1))
+                                                ).toList()
+                                        );
+                                    })
+                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+
+                            List<Map.Entry<Serializable[],Serializable[]>> rows = changedData.getRows();
+
+                             //이벤트 타입, 필터된 컬럼데이터
+                             //Before Rows와 After Rows의 지정 인덱스가 바뀌었는지 변화 감지
+                            //감지한 컬럼 인덱스로 컬럼 내용 변화 감지.
+                            rows.stream()
+                                    .map(row -> {
+                                        // key와 value가 각각 before after
+                                        Serializable[] before = row.getKey();
+                                        Serializable[] after = row.getValue();
+
+                                        final Map<String, List<String>> filteredValues = new HashMap<>();
+
+                                        resultColumnsIndicesByEvent.forEach((eventName, columnIndices) -> {
+                                            // 각 행의 변화감지 인덱스를 넣어서 만약에 바뀌면 아래를 실행
+                                            int watchedColumnIndex = columnIndices.get(0);
+                                            if (!Objects.equals(before[watchedColumnIndex], after[watchedColumnIndex])) {
+                                                final List<String> values = new ArrayList<>();
+                                                columnIndices.stream()
+                                                        .skip(1)
+                                                        .filter(index -> index >= 0)
+                                                        .forEach(index -> values.add(after[index].toString()));
+                                                filteredValues.put(eventName, Collections.unmodifiableList(values));
+                                            }
+                                        });
+                                        return Collections.unmodifiableMap(filteredValues);
+                                    })
+                                    .toList();
+                        }
+                    });
+                });
+                relatedTableMapEvents.clear();
+            } else if (recordedEventTypes.contains(eventType)) {
+                Long tableId = getTableId(event);
+                if (tableId != null) {
+                    handleEvent(event, tableId);
+                }
+            }
+        });
+        logClient.connect();
+        return logClient;
+    }
+
+
+    private static void handleEvent(Event event, long tableId) {
+
+        relatedTableMapEvents.compute(tableId, (tid, tableMapInfo) -> {
+            if (tableMapInfo == null) {
+               tableMapInfo = new TableMapInfo();
+            }
+
+            if (event.getHeader().getEventType().equals(EventType.TABLE_MAP) ) {
+                // 테이블 매핑 정보 처리
+                tableMapInfo.setTableMapEventData(event.getData());
+            } else {
+                // 실제 변경 이벤트 처리
+                if (tableMapInfo.dmlEvents == null) {
+                    tableMapInfo.dmlEvents = new HashSet<>();
+                }
+                tableMapInfo.dmlEvents.add(event);
+            }
+            return tableMapInfo;
+        });
+    }
+    private static Long getTableId(Event event) {
+        EventData eventData = event.getData();
+        Long tableId = null;
+        if (eventData instanceof WriteRowsEventData) {
+            tableId = ((WriteRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof UpdateRowsEventData) {
+            tableId = ((UpdateRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof DeleteRowsEventData) {
+            tableId = ((DeleteRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof TableMapEventData) {
+            tableId = ((TableMapEventData) eventData).getTableId();
+        }
+        return tableId;
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
@@ -49,7 +49,6 @@ public class TableEventListener {
     private static final Set<EventType> recordedEventTypes = Set.of(EventType.EXT_WRITE_ROWS, EventType.EXT_UPDATE_ROWS, EventType.EXT_DELETE_ROWS, EventType.TABLE_MAP);
     private static final Map<Long, TableMapInfo> relatedTableMapEvents = new HashMap<>();
 
-    //TODO : static 클래스 빈 객체로 생성해서 사용하기(리팩토링)
     @Data
     private static class TableMapInfo {
         private TableMapEventData tableMapEventData;
@@ -197,7 +196,6 @@ public class TableEventListener {
                                     .toList();
 
 
-                            // @TODO: 이제 테이블명과 변경된 로우 ID 매핑 후, 컬럼 값들을 파싱하고 처리하는 클래스에 넘겨주기
                             // 필요한 테이블 : bill, CongressMan
                             // 컬럼 : 의원이 새로운 법안을 발의함(bill의 bill_name), 의원이 새로 추가됨(name)
                             // 알림 보내야할 테이블이면 bill_name 혹은 의원 이름을 추출해서 알림 메시지로 보내버림
@@ -208,7 +206,6 @@ public class TableEventListener {
                             //final DeleteRowsEventData insertedData = (DeleteRowsEventData) data;
                         } else if (data instanceof UpdateRowsEventData changedData) {
 
-                            // @TODO: 이제 테이블명과 변경된 로우 ID 매핑 후, 컬럼 값들을 파싱하고 처리하는 클래스에 넘겨주기
                             // 필요한 테이블 : bill, CongressMan
                             // 컬럼 : 법안의 처리상태 변동(bill의 bill_name, stage), 의원의 정당 바뀜(이름, 바뀐정당)
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/internal/model/WatchedColumnEvent.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/internal/model/WatchedColumnEvent.java
@@ -1,0 +1,18 @@
+package com.everyones.lawmaking.global.internal.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+
+@Data
+public class WatchedColumnEvent {
+    public enum ColumnEventType {
+        INSERT, UPDATE, DELETE
+    }
+    private final String eventName;
+    private final String tableName;
+    private final String columnName;
+    private final ColumnEventType eventType;
+    private final List<String> resultColumnNames;
+}

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -26,6 +26,15 @@ app.auth.token-secret= ${TOKEN_SECRET}
 app.auth.token-expiry= ${TOKEN_EXPIRY}
 app.auth.refresh-token-expiry= ${REFRESH_TOKEN_EXPIRY}
 
+# binlog configurations
+binlog.host = ${BIN_LOG_HOST}
+binlog.port = ${BIN_LOG_PORT}
+binlog.user = ${BIN_LOG_USER}
+binlog.password = ${BIN_LOG_PASSWORD}
+
+# DB connection configuration
+db-connection-pool.db-name = ${DB_NAME}
+
 spring.security.oauth2.client.registration.kakao.client-id = ${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret = ${KAKAO_CLIENT_SECRET}
 spring.security.oauth2.client.registration.kakao.scope = profile_nickname, account_email, profile_image


### PR DESCRIPTION
## 개요
카테고리 별 알림 발송 기능

### 세부 사항
자바 어플리케이션에서 알림을 관리하기 위해 데이터 변경시 기록하는 bin log를 캐치하여 알림을 구현

시간 순서대로 리스트를 받지 않는 문제가 있음 만약 수정 삭제 생성이 한 트랜잭션에서 여러 작업이 동시에 일어나는 경우
잘못된 알림이 발생할 경우가 있음. <- 해당 사항은 추후 리팩토링을 거쳐야할 필요가 있음.

bin log 캐치할 때 WatchedColumnEvent 의 테이블을 반드시 소문자로 해야하는데 아직 파악못함
작동에는 영향이 없어서 추후 리팩토링때 작업 필요