### PR TITLE
카테고리 별 알림 발송 기능

### DIFF
--- a/lawmaking/build.gradle
+++ b/lawmaking/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // mysql bin log connector
+    implementation group: 'com.zendesk', name: 'mysql-binlog-connector-java', version: '0.29.0'
+
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.hibernate:hibernate-validator:7.0.5.Final'

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/UserDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/UserDto.java
@@ -1,0 +1,15 @@
+package com.everyones.lawmaking.common.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserDto {
+    private long id;
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -1,0 +1,41 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.global.util.NotificationConverter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class NotificationResponse {
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+
+    @NotNull
+    private String target;
+
+    @NotNull
+    private String type;
+
+    @NotNull
+    private LocalDateTime createdDate;
+
+    // notifications 리스트를 NotificationResponse 리스트로 만들어주는 메서드
+    public static List<NotificationResponse> from(List<Notification> notifications) {
+        return notifications.stream().map(NotificationConverter::from).toList();
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
@@ -1,0 +1,73 @@
+package com.everyones.lawmaking.controller;
+
+import com.everyones.lawmaking.common.dto.response.NotificationResponse;
+import com.everyones.lawmaking.facade.Facade;
+import com.everyones.lawmaking.global.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/notification")
+@Tag(name="알림 관련 API", description = "알림 조회 및 생성 삭제 기능 포함")
+public class NotificationController {
+
+    private final Facade facade;
+
+    @Operation(summary = "알림 조회 API", description = "발송 되지 않았고 읽지 않은 알림을 조회한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @GetMapping("/")
+    public BaseResponse<List<NotificationResponse>> getNotifications(Authentication authentication) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.getNotifications(Long.parseLong(user.getPassword()));
+        return BaseResponse.ok(result);
+    }
+
+    @Operation(summary = "알림 읽음 처리 API", description = "모든 알림을 읽음 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PutMapping("/read")
+    public BaseResponse<List<NotificationResponse>> readNotification(Authentication authentication) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.readNotifications(Long.parseLong(user.getPassword()));
+        return BaseResponse.ok(result);
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
@@ -43,7 +43,7 @@ public class NotificationController {
                     )}
             ),
     })
-    @GetMapping("/")
+    @GetMapping("")
     public BaseResponse<List<NotificationResponse>> getNotifications(Authentication authentication) {
         final UserDetails user = (UserDetails) authentication.getPrincipal();
         var result = facade.getNotifications(Long.parseLong(user.getPassword()));

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BaseEntity.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
@@ -1,0 +1,47 @@
+package com.everyones.lawmaking.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+@AllArgsConstructor
+@Getter
+public enum ColumnEventType {
+    RP_INSERT("rp_insert",
+            "representativeproposer",
+            null,
+            EventType.INSERT,
+            List.of("congressman_id","bill_id")),
+    BILL_STAGE_UPDATE(
+            "bill_stage_update",
+            "bill",
+            "stage",
+            EventType.UPDATE,
+            List.of("bill_id", "bill_name", "proposers", "stage")),
+    CONGRESSMAN_PARTY_UPDATE(
+            "congressman_party_update",
+            "congressman",
+            "party_id",
+            EventType.UPDATE,
+            List.of("congressman_id", "party_id", "name"));
+
+    public enum EventType {
+        INSERT, UPDATE, DELETE
+    }
+    private final String eventName;
+    private final String tableName;
+    private final String columnName;
+    private final EventType eventType;
+    private final List<String> resultColumnNames;
+
+    public static ColumnEventType from(String code) {
+        return Arrays.stream(ColumnEventType.values())
+                .filter(cet -> cet.getEventName().equals(code))
+                .findAny()
+                .orElseThrow();
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Notification.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Notification.java
@@ -1,0 +1,46 @@
+package com.everyones.lawmaking.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 알림 이름(유형)
+    @NotNull
+    @Enumerated
+    @Column(name = "notification_name")
+    private ColumnEventType notificationName;
+
+    // 알림 내용
+    @NotNull
+    @Column(name = "notification_content_json")
+    private String contentJson;
+
+    // 알림을 보냈는지 여부
+    @NotNull
+    @Column(name = "is_sent")
+    private boolean isSent;
+
+    // 사용자가 알림을 읽음 여부
+    @NotNull
+    @Column(name = "is_read")
+    private boolean isRead;
+
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -130,7 +130,7 @@ public class Facade {
         var congressmanId = congressman.getId();
         var congressmanName = congressman.getName();
 
-        var party = congressmanService.findCongressman(raw.get(1));
+        var party = partyService.findParty(Long.parseLong(raw.get(1)));
         var partyName = party.getName();
 
         return List.of(congressmanId, partyName, congressmanName);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -1,13 +1,16 @@
 package com.everyones.lawmaking.facade;
 
 import com.everyones.lawmaking.common.dto.BillDto;
-import com.everyones.lawmaking.common.dto.response.CongressmanResponse;
 import com.everyones.lawmaking.common.dto.response.*;
+import com.everyones.lawmaking.domain.entity.ColumnEventType;
+import com.everyones.lawmaking.domain.entity.User;
 import com.everyones.lawmaking.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class Facade {
     private final CongressmanService congressmanService;
     private final LikeService likeService;
     private final UserService userService;
+    private final NotificationService notificationService;
 
     // default로 메인피드에 띄울 법안 가져오기 현재 최신순으로 반환해줌.
     public BillListResponse getBillsFromMainFeed(Pageable pageable) {
@@ -94,7 +98,48 @@ public class Facade {
     }
 
 
+    // 알림 조회
+    public List<NotificationResponse> getNotifications(long userId){
+        return notificationService.getNotifications(userId);
+    }
 
+    // 알림 읽음 처리
+    public List<NotificationResponse> readNotifications(long userId) {
+        return notificationService.readNotifications(userId);
+    }
 
+    // 알림 데이터를 각 테이블에 해당하는 실제 데이터로 변환 (ex : bill_id
 
+    public List<String> rpInsert(List<String> raw) {
+        var congressman = congressmanService.findCongressman(raw.get(0));
+        var billRepProposer = congressman.getName();
+
+        var bill = billService.getBillEntityById(raw.get(1));
+        var billId = bill.getId();
+        var billName = bill.getBillName();
+        var billProposers = bill.getProposers();
+
+        return List.of(billId, billRepProposer, billProposers, billName);
+    }
+    public List<String> billStageUpdate(List<String> raw) {
+        return raw;
+    }
+
+    public List<String> congressmanPartyUpdate(List<String> raw) {
+        var congressman = congressmanService.findCongressman(raw.get(0));
+        var congressmanId = congressman.getId();
+        var congressmanName = congressman.getName();
+
+        var party = congressmanService.findCongressman(raw.get(1));
+        var partyName = party.getName();
+
+        return List.of(congressmanId, partyName, congressmanName);
+    }
+
+    public List<User> getSubscribedUsers(ColumnEventType cet, String targetId) {
+        return switch (cet) {
+            case RP_INSERT, CONGRESSMAN_PARTY_UPDATE -> likeService.getUserByLikedCongressmanId(targetId);
+            case BILL_STAGE_UPDATE -> likeService.getUserByLikedBillId(targetId);
+        };
+    }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/BaseResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/BaseResponse.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @SuperBuilder
 @Schema(description="API 응답 최상위 오브젝트")
-public class BaseResponse<T>{
+public class BaseResponse<T> {
+
     @Schema(description = "성공 여부")
     private HttpStatus status;
     @Schema(description = "응답 코드 (HTTP 코드와 동일)", defaultValue = "200")
@@ -21,9 +22,8 @@ public class BaseResponse<T>{
     @Schema(description = "응답 본문 오브젝트")
     private T data;
 
-
-    public static <T> BaseResponse ok(T data) {
-        return BaseResponse.builder()
+    public static <T> BaseResponse<T> ok(T data) {
+        return BaseResponse.<T>builder()
                 .code(ResponseCode.OK.getCode())
                 .status(ResponseCode.OK.getStatus())
                 .message(ResponseCode.OK.getMessage())
@@ -40,4 +40,5 @@ public class BaseResponse<T>{
                 .data(data)
                 .build();
     }
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
@@ -1,0 +1,51 @@
+package com.everyones.lawmaking.global.config;
+
+import com.everyones.lawmaking.domain.entity.ColumnEventType;
+import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.domain.entity.User;
+import com.everyones.lawmaking.facade.Facade;
+import com.everyones.lawmaking.global.CustomException;
+import com.everyones.lawmaking.global.ResponseCode;
+import com.everyones.lawmaking.repository.NotificationRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationCreator {
+
+    private final NotificationRepository notificationRepository;
+    private final Facade facade;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void createNotification(List<Map<String, List<String>>> filteredValuesByRows) {
+        List<Notification> notifications = new ArrayList<>();
+        filteredValuesByRows.forEach((eventDataByEventTypeMap) -> {
+                    eventDataByEventTypeMap.forEach((eventType, eventData) -> {
+                        try {
+                            ColumnEventType columnEventType = ColumnEventType.from(eventType);
+                            String jsonString = objectMapper.writeValueAsString(eventData);
+                            List<User> subscribedSavedUser = facade.getSubscribedUsers(columnEventType, eventData.get(0));
+                            subscribedSavedUser
+                                    .forEach(user -> {
+                                        notifications.add(
+                                        Notification.builder()
+                                                .notificationName(columnEventType)
+                                                .contentJson(jsonString)
+                                                .user(user)
+                                                .build());
+                                    });
+                        } catch (JsonProcessingException e) {
+                            throw new CustomException(ResponseCode.INTERNAL_SERVER_ERROR);
+                        }
+                    });
+                });
+        notificationRepository.saveAll(notifications);
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
@@ -1,0 +1,304 @@
+package com.everyones.lawmaking.global.config;
+
+import com.everyones.lawmaking.domain.entity.ColumnEventType;
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.*;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "binlog")
+public class TableEventListener {
+    /**
+     * DB host(ipv4)
+     */
+    @Value("${binlog.host}")
+    private String host;
+    /**
+     * DB port
+     */
+    @Value("${binlog.port}")
+    private int port;
+    /**
+     * DB username
+     */
+    @Value("${binlog.user}")
+    private String user;
+    /**
+     * DB password
+     */
+    @Value("${binlog.password}")
+    private String password;
+
+    @Value("${db-connection-pool.db-name}")
+    private String dbName;
+
+    private final Set<EventType> recordedEventTypes = Set.of(EventType.EXT_WRITE_ROWS, EventType.EXT_UPDATE_ROWS, EventType.EXT_DELETE_ROWS, EventType.TABLE_MAP);
+    private final Map<Long, TableMapInfo> relatedTableMapEvents = new HashMap<>();
+
+    private final NotificationCreator notificationCreator;
+
+    /**
+     * 테이블별 (컬럼네임,컬럼 인덱스) 정보 가져오는 메서드
+     * @return Map(테이블명, Map(컬럼명, 컬럼 인덱스))
+     */
+    Map<String, Map<String, Integer>> fetchColumnOrdersByTable() {
+        Map<String, Map<String, Integer>> columnOrdersByTable = new HashMap<>();
+
+        // 커넥션 풀 새로 만들어서 컬럼 이름 가져오기
+        try (Connection connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port, user, password)) {
+            // try with 구문 시작
+            // connection의 메타데이터를 가져와서
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet tableResultSet = metaData.getTables(dbName, "public", null, new String[]{"TABLE"})) {
+                // metaData의 테이블 정보를 가져옴
+                while (tableResultSet.next()) {
+                    // 테이블 이름을 tableName에 저장
+                    String tableName = tableResultSet.getString("TABLE_NAME").toLowerCase();
+
+                    // 컬럼 네임별 인덱스 저장할 해시맵 생성
+                    Map<String, Integer> columnOrders = new HashMap<>();
+
+                    // 해당 table의 컬럼 가져와서 try-with 구문 시작
+                    try (ResultSet columnResultSet = metaData.getColumns(dbName, "public", tableName, null)) {
+                        // 컬럼 이름과 컬럼 매칭 인덱스를 맵에 저장
+                        while (columnResultSet.next()) {
+                            columnOrders.put(columnResultSet.getString("COLUMN_NAME").toLowerCase(), columnResultSet.getInt("ORDINAL_POSITION") - 1);
+                        }
+                    }
+                    // 테이블 당 컬럼들의 네임과 인덱스를 저장한 해시맵을 put
+                    columnOrdersByTable.put(tableName, Collections.unmodifiableMap(columnOrders));
+                }
+
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Collections.unmodifiableMap(columnOrdersByTable);
+    }
+
+
+    @Bean(destroyMethod = "disconnect")
+    BinaryLogClient binaryLogClient() throws IOException {
+        final Map<String, Map<String, Integer>> columnOrdersByTable = fetchColumnOrdersByTable();
+
+        final List<ColumnEventType> watchedColumnEvents = List.of(ColumnEventType.values());
+
+        final List<String> watchedTableNames = watchedColumnEvents.stream().map(ColumnEventType::getTableName).toList();
+
+        BinaryLogClient logClient = new BinaryLogClient(
+                host,
+                port,
+                user,
+                password);
+
+        // 받은 데이터를 BYTE 로 표현
+        EventDeserializer eventDeserializer = new EventDeserializer();
+        eventDeserializer.setCompatibilityMode(
+                EventDeserializer.CompatibilityMode.DATE_AND_TIME_AS_LONG,
+                EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY
+        );
+
+        logClient.registerEventListener(event -> {
+            // 이벤트 타입에 따라서 Data가 없는 것도 있음.
+            // 따라서 바로 event.getData를 호출하는 것은 주의
+            final EventType eventType = event.getHeader().getEventType();
+            if (eventType == EventType.XID) {
+
+                List<Map<String, List<String>>> filteredValuesByRows = new ArrayList<>();
+
+                // Operation에 따라서 before after 변화를 감지.
+                relatedTableMapEvents.forEach((_tableId, tableMapInfo) -> {
+                    // 여기서 매핑정보들 테이블id 와 before after 변화 감지해서 원하는 알림처리 메소드 호출
+                    final TableMapEventData tableMapEventData = tableMapInfo.getTableMapEventData();
+
+                    final String tableName = tableMapEventData.getTable().toLowerCase();
+                    // 이벤트 감지가 필요없는 테이블이면 스킵
+                    // tableName은 all 소문자로 옴
+                    if (!watchedTableNames.contains(tableName)) return;
+
+                    final Set<Event> dmlOperations = tableMapInfo.getDmlEvents();
+                    //TODO: 시간 순서대로 리스트를 받지 않는 문제가 있음 만약 수정 삭제 생성이 한 트랜잭션에서 여러 작업이 동시에 일어나는 경우 잘못된 알림이 발생할 경우가 있음.
+                    dmlOperations.forEach(e -> {
+                        final EventData data = e.getData();
+                        // 하나의 트랜잭션에는 여러개의 로우가 관여할 수 있음, 또한 하나의 Serializable 객체는 하나의 컬럼 값임.
+                        if (data instanceof WriteRowsEventData insertedData) {
+                            List<Serializable[]> rows = insertedData.getRows();
+
+                            // WriteRows에 관한 알림처리할 컬럼 인덱스 필터링
+                            // 알림 데이터로 필요한 (이벤트네임, 컬럼 인덱스)를 저장
+                            Map<String, List<Integer>> resultColumnsIndicesByEvent = watchedColumnEvents
+                                    .stream()
+                                    .filter(wce -> tableName.equalsIgnoreCase(wce.getTableName())
+                                            && wce.getEventType() == ColumnEventType.EventType.INSERT)
+                                    .map(wce -> {
+                                        final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName, new HashMap<>());
+                                        return new AbstractMap.SimpleEntry<>(
+                                                wce.getEventName(),
+                                                wce.getResultColumnNames()
+                                                        .stream()
+                                                        .map(columnName ->
+                                                                columnOrdersForTable.getOrDefault(columnName.toLowerCase(), -1))
+                                                        .toList()
+
+                                        );
+                                    })
+                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                            // 이벤트 타입, 필터된 컬럼데이터
+                            filteredValuesByRows.addAll(
+                            rows.stream()
+                                    .map(row -> {
+                                        final Map<String, List<String>> filteredValues = new HashMap<>();
+                                        resultColumnsIndicesByEvent.forEach((eventName, columnIndices) -> {
+                                            final List<String> values = new ArrayList<>();
+                                            columnIndices.stream().filter(index->index>=0).forEach((index) -> values.add(row[index].toString()));
+                                            filteredValues.put(eventName, Collections.unmodifiableList(values));
+                                        });
+                                        return Collections.unmodifiableMap(filteredValues);
+                                    })
+                                    .toList());
+
+
+                            // 필요한 테이블 : bill, CongressMan
+                            // 컬럼 : 의원이 새로운 법안을 발의함(bill의 bill_name), 의원이 새로 추가됨(name)
+                            // 알림 보내야할 테이블이면 bill_name 혹은 의원 이름을 추출해서 알림 메시지로 보내버림
+
+
+                            // @TODO: 데이터 삭제 알림 필요시 주석 해제
+                            //} else if (data instanceof DeleteRowsEventData) {
+                            //final DeleteRowsEventData insertedData = (DeleteRowsEventData) data;
+                        } else if (data instanceof UpdateRowsEventData changedData) {
+
+                            // 필요한 테이블 : bill, CongressMan
+                            // 컬럼 : 법안의 처리상태 변동(bill의 bill_name, stage), 의원의 정당 바뀜(이름, 바뀐정당)
+
+                            //List로 스트림 건 후 before after를 지정 컬럼으로 확인
+                            // 알림 이벤트 타입이랑 인덱스 추출
+                            Map<String, List<Integer>> resultColumnsIndicesByEvent = watchedColumnEvents
+                                    .stream()
+                                    .filter(wce -> tableName.equalsIgnoreCase(wce.getTableName())
+                                            && wce.getEventType() == ColumnEventType.EventType.UPDATE)
+                                    .map(wce -> {
+                                        final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName, new HashMap<>());
+                                        return new AbstractMap.SimpleEntry<>(
+                                                wce.getEventName(),
+                                                Stream.concat(
+                                                        Stream.of(columnOrdersForTable.getOrDefault(wce.getColumnName().toLowerCase(), -1)),
+                                                        wce.getResultColumnNames()
+                                                                .stream()
+                                                                .map(columnName ->
+                                                                        columnOrdersForTable.getOrDefault(columnName.toLowerCase(), -1))
+                                                ).toList()
+                                        );
+                                    })
+                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+
+                            List<Map.Entry<Serializable[],Serializable[]>> rows = changedData.getRows();
+
+                            //이벤트 타입, 필터된 컬럼데이터
+                            //Before Rows와 After Rows의 지정 인덱스가 바뀌었는지 변화 감지
+                            //감지한 컬럼 인덱스로 컬럼 내용 변화 감지.
+                            filteredValuesByRows.addAll(
+                            rows.stream()
+                                    .map(row -> {
+                                        // key와 value가 각각 before after
+                                        Serializable[] before = row.getKey();
+                                        Serializable[] after = row.getValue();
+
+                                        final Map<String, List<String>> filteredValues = new HashMap<>();
+
+                                        resultColumnsIndicesByEvent.forEach((eventName, columnIndices) -> {
+                                            // 각 행의 변화감지 인덱스를 넣어서 만약에 바뀌면 아래를 실행
+                                            int watchedColumnIndex = columnIndices.get(0);
+                                            if (!Objects.equals(before[watchedColumnIndex], after[watchedColumnIndex])) {
+                                                final List<String> values = new ArrayList<>();
+                                                columnIndices.stream()
+                                                        .skip(1)
+                                                        .filter(index -> index >= 0)
+                                                        .forEach(index -> values.add(after[index].toString()));
+                                                filteredValues.put(eventName, Collections.unmodifiableList(values));
+                                            }
+                                        });
+                                        return Collections.unmodifiableMap(filteredValues);
+                                    })
+                                    .toList());
+                        }
+                    });
+                });
+
+                notificationCreator.createNotification(filteredValuesByRows);
+
+                relatedTableMapEvents.clear();
+            } else if (recordedEventTypes.contains(eventType)) {
+                Long tableId = getTableId(event);
+                if (tableId != null) {
+                    handleEvent(event, tableId);
+                }
+            }
+        });
+        logClient.setBlocking(false);
+        logClient.connect();
+        return logClient;
+    }
+
+
+    private void handleEvent(Event event, long tableId) {
+
+        relatedTableMapEvents.compute(tableId, (tid, tableMapInfo) -> {
+            if (tableMapInfo == null) {
+                tableMapInfo = new TableMapInfo();
+            }
+
+            if (event.getHeader().getEventType().equals(EventType.TABLE_MAP) ) {
+                // 테이블 매핑 정보 처리
+                tableMapInfo.setTableMapEventData(event.getData());
+            } else {
+                // 실제 변경 이벤트 처리
+                if (tableMapInfo.getDmlEvents() == null) {
+                    tableMapInfo.setDmlEvents(new HashSet<>());
+                }
+                tableMapInfo.getDmlEvents().add(event);
+            }
+            return tableMapInfo;
+        });
+    }
+    private static Long getTableId(Event event) {
+        EventData eventData = event.getData();
+        Long tableId = null;
+        if (eventData instanceof WriteRowsEventData) {
+            tableId = ((WriteRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof UpdateRowsEventData) {
+            tableId = ((UpdateRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof DeleteRowsEventData) {
+            tableId = ((DeleteRowsEventData) eventData).getTableId();
+        }
+        else if (eventData instanceof TableMapEventData) {
+            tableId = ((TableMapEventData) eventData).getTableId();
+        }
+        return tableId;
+    }
+}
+
+@Data
+class TableMapInfo {
+    private TableMapEventData tableMapEventData;
+    private Set<Event> dmlEvents;
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -1,0 +1,90 @@
+package com.everyones.lawmaking.global.util;
+
+import com.everyones.lawmaking.common.dto.response.NotificationResponse;
+import com.everyones.lawmaking.domain.entity.ColumnEventType;
+import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.facade.Facade;
+import com.everyones.lawmaking.global.CustomException;
+import com.everyones.lawmaking.global.ResponseCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class NotificationConverter {
+
+    // NotificationResponse를 만드는 메소드가 static 메소드 이기에 안에 들어가는 객체들도 전부 static이어야 함.
+    // static을 하지 않으면 사용하는 객체를 생성할 때 facade를 계속 의존성 주입 해줘야함
+    // 그런데 NotificationResponse Dto 클래스에 Facade 의존성 주입을 해주는 것이 클래스 목적성을 흐린다고 생각하여 해당 클래스를 만듦.
+    // 따라서 처음에 facade를 static으로 선언 된 것을 필드 주입을 통해서 facade 인스턴스를 초기화
+    private static Facade facade;
+
+    @Autowired
+    private void setFacade(Facade facade) {
+        NotificationConverter.facade = facade;
+    }
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static List<String> parseData(String data) {
+        try {
+            return mapper.readValue(data, new TypeReference<List<String>>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public static NotificationResponse from(Notification notification) {
+        ColumnEventType columnEventType = notification.getNotificationName();
+        List<String> data = parseData(notification.getContentJson());
+        String type = columnEventType.getEventName();
+        String target = data.get(0);
+        String title = null;
+        String content = null;
+        List<String> processedData;
+        switch (columnEventType) {
+            case RP_INSERT:
+                processedData = facade.rpInsert(data);
+                // List.of(billId, billRepProposer, billProposers, billName)
+                title = processedData.get(1) + " 의원";
+                content = processedData.get(2) + "이 '" + processedData.get(3) + "'을/를 발의했어요!";
+                break;
+            case BILL_STAGE_UPDATE:
+                // List.of("bill_id", "bill_name", "proposers", "stage")
+                processedData = facade.billStageUpdate(data);
+                title = processedData.get(1) + " " + processedData.get(2);
+                content = "스크랩한 법안이 본회의에서 '"+processedData.get(3)+"'되었어요!";
+                break;
+            case CONGRESSMAN_PARTY_UPDATE:
+                // List.of(congressmanId, partyName, congressmanName);
+                processedData = facade.congressmanPartyUpdate(data);
+                title = processedData.get(1);
+                content = "'"+processedData.get(2)+"'의원의 당적이 '"+processedData.get(1)+"'(으)로 변동했어요!";
+                break;
+        }
+
+        LocalDateTime createdDate = notification.getCreatedDate();
+
+        if (type == null || target == null || title == null || content == null || createdDate.isAfter(LocalDateTime.now())) {
+            throw new CustomException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+
+
+        return NotificationResponse.builder()
+                // 이벤트 타입
+                .type(type)
+                // 알림 이미지 id값
+                .target(target)
+                .title(title)
+                .content(content)
+                .createdDate(createdDate)
+                .build();
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -1,11 +1,13 @@
 package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.BillLike;
+import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +16,9 @@ public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
     @Query("select bl from BillLike bl " +
             "where bl.bill.id = :billId AND bl.user.id = :userId")
     Optional<BillLike> findByUserIdAndBillId(@Param("userId") long userId, @Param("billId") String billId);
+
+    @Query("select bl.user from BillLike bl " +
+            "where bl.bill.id = :billId")
+    List<User> findAllByBillId(@Param("billId") String billId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -1,11 +1,13 @@
 package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.CongressManLike;
+import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +16,9 @@ public interface CongressmanLikeRepository extends JpaRepository<CongressManLike
     @Query("SELECT cl FROM CongressManLike cl " +
             "WHERE cl.user.id = :userId AND cl.congressMan.id = :congressmanId")
     Optional<CongressManLike> findByUserIdAndCongressmanId(@Param("userId")long userId, @Param("congressmanId")String congressmanId);
+
+    @Query("SELECT cl.user FROM CongressManLike cl " +
+            "WHERE cl.congressMan.id = :congressmanId")
+    List<User> findAllByCongressmanId(@Param("congressmanId") String congressmanId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
@@ -1,0 +1,24 @@
+package com.everyones.lawmaking.repository;
+
+
+import com.everyones.lawmaking.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("""
+            select n
+            from Notification n
+            Join User u on u.id = :userId
+            where n.user.id = :userId
+            """)
+    List<Notification> findAllByUserId(@Param("userId") Long userId);
+
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -105,5 +107,12 @@ public class LikeService {
         return BillLikeResponse.from(updatedBillLike);
     }
 
+    public List<User> getUserByLikedBillId(String billId) {
+        return billLikeRepository.findAllByBillId(billId);
+    }
+
+    public List<User> getUserByLikedCongressmanId(String congressmanId) {
+        return congressmanLikeRepository.findAllByCongressmanId(congressmanId);
+    }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -1,0 +1,33 @@
+package com.everyones.lawmaking.service;
+
+import com.everyones.lawmaking.common.dto.response.NotificationResponse;
+import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    public List<NotificationResponse> getNotifications(long userId){
+        List<Notification> notifications = notificationRepository.findAllByUserId(userId);
+
+        return NotificationResponse.from(notifications);
+    }
+
+
+
+    public List<NotificationResponse> readNotifications(long userId){
+        List<Notification> notifications = notificationRepository.findAllByUserId(userId);
+
+        notifications.forEach((noti)-> noti.setRead(true));
+
+        List<Notification> notificationsRead = notificationRepository.saveAll(notifications);
+
+        return NotificationResponse.from(notificationsRead);
+    }
+}

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -26,6 +26,15 @@ app.auth.token-secret= ${TOKEN_SECRET}
 app.auth.token-expiry= ${TOKEN_EXPIRY}
 app.auth.refresh-token-expiry= ${REFRESH_TOKEN_EXPIRY}
 
+# binlog configurations
+binlog.host = ${BIN_LOG_HOST}
+binlog.port = ${BIN_LOG_PORT}
+binlog.user = ${BIN_LOG_USER}
+binlog.password = ${BIN_LOG_PASSWORD}
+
+# DB connection configuration
+db-connection-pool.db-name = ${DB_NAME}
+
 spring.security.oauth2.client.registration.kakao.client-id = ${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret = ${KAKAO_CLIENT_SECRET}
 spring.security.oauth2.client.registration.kakao.scope = profile_nickname, account_email, profile_image


### PR DESCRIPTION
## 개요
카테고리 별 알림 발송 기능

### 세부 사항
자바 어플리케이션에서 알림을 관리하기 위해 데이터 변경시 기록하는 bin log를 캐치하여 알림을 구현

시간 순서대로 리스트를 받지 않는 문제가 있음 만약 수정 삭제 생성이 한 트랜잭션에서 여러 작업이 동시에 일어나는 경우
잘못된 알림이 발생할 경우가 있음. <- 해당 사항은 추후 리팩토링을 거쳐야할 필요가 있음.

bin log 캐치할 때 ColumnEventType 의 테이블이름을 반드시 소문자로 해야하는데 아직 파악못함
작동에는 영향이 없어서 추후 리팩토링때 작업 필요