### PR TITLE
Swagger에서 Api 요청 시 토큰 자동으로 삽입 기능 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SwaggerConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SwaggerConfig.java
@@ -3,17 +3,30 @@ package com.everyones.lawmaking.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearer-token");
+
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components()
+                .addSecuritySchemes("bearer-token",securityScheme))
+                .security(Collections.singletonList(securityRequirement))
                 .info(apiInfo());
     }
 


### PR DESCRIPTION
## 1. 내용
로그인 기능이 도입 되면서, JWT가 필수적인 API들을 호출 시 자동으로 jwt토큰을 넣어줘야 테스트에 편리하기에
Authorization Bearer토큰을 공통적으로 헤더에 추가해주는 기능을 추가함.