### PR TITLE
FIX : 카카오 토큰 발급 리다이렉션 페이지 로컬호스트 테스트용

### DIFF
--- a/lawmaking/src/main/resources/application-local.properties
+++ b/lawmaking/src/main/resources/application-local.properties
@@ -10,5 +10,5 @@ spring.jpa.generate-ddl=false
 #spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 #Kakao
-spring.security.oauth2.client.registration.kakao.redirect-uri = http://52.79.63.140:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri = http://localhost:8080/login/oauth2/code/kakao
 


### PR DESCRIPTION
##내용
카카오 로그인 로컬테스트 용 토큰 Redirect Uri 수정