### PR TITLE
Fix: 알림 api 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Notification.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Notification.java
@@ -23,7 +23,7 @@ public class Notification extends BaseEntity {
 
     // 알림 이름(유형)
     @NotNull
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(name = "notification_name")
     private ColumnEventType notificationName;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -185,8 +185,8 @@ public class Facade {
 
     public List<User> getSubscribedUsers(ColumnEventType cet, String targetId) {
         return switch (cet) {
-            case RP_INSERT, CONGRESSMAN_PARTY_UPDATE -> likeService.getUserByLikedCongressmanId(targetId);
-            case BILL_STAGE_UPDATE -> likeService.getUserByLikedBillId(targetId);
+            case RP_INSERT, CONGRESSMAN_PARTY_UPDATE -> userService.getUserByLikedCongressmanId(targetId);
+            case BILL_STAGE_UPDATE -> userService.getUserByLikedBillId(targetId);
         };
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -1,13 +1,11 @@
 package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.BillLike;
-import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,8 +15,6 @@ public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
             "where bl.bill.id = :billId AND bl.user.id = :userId")
     Optional<BillLike> findByUserIdAndBillId(@Param("userId") long userId, @Param("billId") String billId);
 
-    @Query("select bl.user from BillLike bl " +
-            "where bl.bill.id = :billId")
-    List<User> findAllByBillId(@Param("billId") String billId);
+
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -1,13 +1,11 @@
 package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.CongressManLike;
-import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,9 +15,7 @@ public interface CongressmanLikeRepository extends JpaRepository<CongressManLike
             "WHERE cl.user.id = :userId AND cl.congressman.id = :congressmanId")
     Optional<CongressManLike> findByUserIdAndCongressmanId(@Param("userId")long userId, @Param("congressmanId")String congressmanId);
 
-    @Query("SELECT cl.user FROM CongressManLike cl " +
-            "WHERE cl.congressman.id = :congressmanId")
-    List<User> findAllByCongressmanId(@Param("congressmanId") String congressmanId);
+
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
@@ -2,13 +2,24 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByAuthInfo_Id(Long authInfoId);
+
+    @Query("SELECT cl.user FROM CongressManLike cl " +
+            "WHERE cl.congressman.id = :congressmanId")
+    List<User> findAllByCongressmanId(@Param("congressmanId") String congressmanId);
+
+    @Query("select bl.user from BillLike bl " +
+            "where bl.bill.id = :billId")
+    List<User> findAllByBillId(@Param("billId") String billId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -12,8 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -108,12 +106,6 @@ public class LikeService {
         return BillLikeResponse.from(updatedBillLike);
     }
 
-    public List<User> getUserByLikedBillId(String billId) {
-        return billLikeRepository.findAllByBillId(billId);
-    }
 
-    public List<User> getUserByLikedCongressmanId(String congressmanId) {
-        return congressmanLikeRepository.findAllByCongressmanId(congressmanId);
-    }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
@@ -8,6 +8,8 @@ import com.everyones.lawmaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -21,6 +23,14 @@ public class UserService {
     public UserMyPageInfoResponse getUserMyPageInfo(long userId) {
         var user = getUserId(userId);
         return UserMyPageInfoResponse.from(user);
+    }
+
+    public List<User> getUserByLikedBillId(String billId) {
+        return userRepository.findAllByBillId(billId);
+    }
+
+    public List<User> getUserByLikedCongressmanId(String congressmanId) {
+        return userRepository.findAllByCongressmanId(congressmanId);
     }
 
 }


### PR DESCRIPTION
## 내용
1. 구독 사용자 조회 메소드 userService, userRepository로 변경
2. notification_name컬럼 타입변경, 컬럼 이름 변경

## 상세내용
1. 기능은 원래 이상이 없었고 로컬 데이터에 사용자 정보가 잘못넣어졌어서 생긴 일시적인 sql정합성 오류로 service, repository 규칙에 따라
리팩토링
2. Notification 컬럼 중 notification_name의 컬럼 이름이 설정되어있지 않았고, 이넘타입이 아닌 Ordinal로 되어있어서 Enum.String으로 변경