### PR TITLE
Fix : 비례대표 정당 로고 리스트에 정당 이름 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/ProportionalPartyImageListDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/ProportionalPartyImageListDto.java
@@ -17,10 +17,13 @@ public class ProportionalPartyImageListDto {
 
     private String partyImageUrl;
 
+    private String partyName;
+
     public static ProportionalPartyImageListDto from(Party party){
         return ProportionalPartyImageListDto.builder()
                 .partyId(party.getId())
                 .partyImageUrl(party.getPartyImageUrl())
+                .partyName(party.getName())
                 .build();
     }
 }


### PR DESCRIPTION
## 1. 내용
기존 비례대표 정당 로고 리스트 조회에 정당 이름 추가 #121 