### PR TITLE
Fix : 카카오 소셜로그인 https 변경

### DIFF
--- a/lawmaking/src/main/resources/application-prod.properties
+++ b/lawmaking/src/main/resources/application-prod.properties
@@ -11,4 +11,4 @@ spring.jpa.generate-ddl=false
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 #Kakao
-spring.security.oauth2.client.registration.kakao.redirect-uri = https://52.79.63.140:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri = https://lawdigest.net:8080/login/oauth2/code/kakao


### PR DESCRIPTION
## 1. 내용
https 도메인네임으로 변경함