### PR TITLE
Fix : 카카오 소셜로그인 경로 변경

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer ì
                                 .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository())
                         )
                         .redirectionEndpoint(redirection -> redirection
-                                .baseUri("/*/oauth2/code/*")
+                                .baseUri("/v1/login/oauth2/code/*")
                         )
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)

--- a/lawmaking/src/main/resources/application-prod.properties
+++ b/lawmaking/src/main/resources/application-prod.properties
@@ -11,4 +11,4 @@ spring.jpa.generate-ddl=false
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 #Kakao
-spring.security.oauth2.client.registration.kakao.redirect-uri = https://lawdigest.net:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri = https://lawdigest.net/v1/login/oauth2/code/kakao


### PR DESCRIPTION
## 1. 내용
https 배포로 인해 카카오 소셜로그인 사용자 정보 발급 경로 변경