### PR TITLE
쿠키 발급 수정 및 쿠키 삭제 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -20,8 +20,6 @@ import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.Arrays;
-
 @Configuration // Configuration 어노테이션 추가
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -81,7 +79,6 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer �
                         logOut
                         .logoutUrl("/v1/logout")
                         .logoutSuccessHandler(new CustomLogoutSuccessHandler())
-                        .deleteCookies("refreshToken", "accessToken")
 
                 );
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/CustomLogoutSuccessHandler.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/CustomLogoutSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.everyones.lawmaking.global.handler;
 
 import com.everyones.lawmaking.global.BaseResponse;
+import com.everyones.lawmaking.global.util.CookieUtil;
 import com.nimbusds.jose.shaded.gson.Gson;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +11,9 @@ import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuc
 
 import java.io.IOException;
 
+import static com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBasedOnCookieRepository.ACCESS_TOKEN;
+import static com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBasedOnCookieRepository.REFRESH_TOKEN;
+
 public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
 
 
@@ -17,6 +21,9 @@ public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler {
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+        CookieUtil.deleteCookie(request, response, ACCESS_TOKEN);
+
         BaseResponse<String> responseMessage = BaseResponse.ok("Logout succeeded");
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType("application/json");

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/CookieUtil.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/CookieUtil.java
@@ -31,16 +31,19 @@ public class CookieUtil {
         response.addCookie(cookie);
     }
 
+
+
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
         Cookie[] cookies = request.getCookies();
 
         if (cookies != null && cookies.length > 0) {
             for (Cookie cookie : cookies) {
                 if (name.equals(cookie.getName())) {
-                    cookie.setValue("");
-                    cookie.setPath("/");
-                    cookie.setMaxAge(0);
-                    response.addCookie(cookie);
+                    var newCookie = new Cookie(name, null);
+                    newCookie.setHttpOnly(true);
+                    newCookie.setPath("/");
+                    newCookie.setMaxAge(0);
+                    response.addCookie(newCookie);
                 }
             }
         }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -12,6 +12,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository implements Author
     public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
     public final static String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
     public final static String REFRESH_TOKEN = "refreshToken";
+    public final static String ACCESS_TOKEN = "accessToken";
     private final static int COOKIE_EXPIRE_SECONDS = 180;
 
     @Override


### PR DESCRIPTION
## 1. 내용
현재 프론트에서 엑세스토큰을 쿠키에 넣어서 보관하고 있습니다.
하지만 토큰을 만들때 httpOnly쿠키로 만들어야하기에
백엔드에서 쿠키를 발급해야 한다고 생각하여 로그인 시, 엑세스토큰 또한 쿠키로 발급하고자 했습니다.
뿐만아니라, 쿼리파라미터에 엑세스토큰을 두는것이 좋다고 생각하진 않아서 작업하게 되었습니다.

쿠키 유효시간 변경
환경변수에 tokenExpiry관련 환경변수를 30으로 해주시면 될거같습니다.(앱 런칭 시)

쿠키삭제
쿠키삭제가 되지 않았는데, 이유는 쿠키를 발급했던 동일한 설정으로 초기화 쿠키를 생성해줘야했고,(httpOnly-true설정 추가)
테스트 완료하였습니다.