### PR TITLE
Fix : 법안 검색 기능 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -86,27 +86,11 @@ public interface BillRepository extends JpaRepository<Bill, String> {
             "(select bill_id ,match(summary) against(concat('*',:keyword,'*') in boolean mode) as summary_rel,\n" +
             "match(keyword) against(concat('*',:keyword,'*') in boolean mode) as keyword_rel,\n" +
             "match(bill_name) against(concat('*',:keyword,'*') in boolean mode) as bill_name_rel\n" +
-            "from bill) search\n" +
+            "from Bill) search\n" +
             "where keyword_rel >0 or summary_rel>0 or bill_name_rel > 0\n" +
             "order by keyword_rel desc, bill_name_rel desc, summary_rel desc"
             , nativeQuery = true)
     Slice<String> findBillByKeyword(Pageable pageable,@Param("keyword") String keyword);
 
-    @Query(value = "select * " +
-            "from " +
-            "(select *,\n" +
-            "         (\n" +
-            "    (CASE WHEN city_name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
-            "        WHEN district_name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
-            "    WHEN gu_name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
-            "            WHEN party_name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
-            "            WHEN name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
-            "        ELSE 0 END)\n" +
-            "  ) AS relevance_score\n" +
-            "from candidate ) search\n" +
-            "where relevance_score > 0\n" +
-            "order by relevance_score desc;"
-            , nativeQuery = true)
-    Slice<Candidate> findCandidateByKeyword(Pageable pageable, @Param("keyword") String keyword);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CandidateRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CandidateRepository.java
@@ -23,7 +23,7 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long> {
             "            WHEN name LIKE CONCAT('%',:keyword,'%') THEN 1\n" +
             "        ELSE 0 END)\n" +
             "  ) AS relevance_score\n" +
-            "from candidate ) search\n" +
+            "from Candidate ) search\n" +
             "where relevance_score > 0\n;", nativeQuery = true)
     Slice<Candidate> findCandidateByKeyword(Pageable pageable, @Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 1. 내용
법안 검색 관련 에러
테이블 대소문자 구분으로 인식 실패로 보여 네이티브 쿼리의 테이블명을 맨 앞문자를 대문자로 변경