### PR TITLE
Fix : 알림 메시지 조회 시, 쿼리 사용자별로 날리지 않게 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -205,8 +205,9 @@ public class Facade {
     }
     public List<String> updateBillStage(List<String> raw) {
         var party = partyService.getPartyByBillId(raw.get(0));
-        raw.add(party.getPartyImageUrl());
-        return raw;
+
+        return Stream.concat(raw.stream(), Stream.of(party.getPartyImageUrl()))
+                .toList();
     }
 
     public List<String> updateCongressmanParty(List<String> raw) {
@@ -218,6 +219,15 @@ public class Facade {
         var partyName = party.getName();
 
         return List.of(congressmanId, partyName, congressmanName,congressman.getParty().getPartyImageUrl());
+    }
+
+    public List<String> getProcessedData(ColumnEventType cet,List<String> eventData) {
+        return switch (cet) {
+            case RP_INSERT -> rpInsert(eventData);
+            case CONGRESSMAN_PARTY_UPDATE -> updateCongressmanParty(eventData);
+            case BILL_STAGE_UPDATE -> updateBillStage(eventData);
+        };
+
     }
 
     public List<User> getSubscribedUsers(ColumnEventType cet, String targetId) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
@@ -30,8 +30,10 @@ public class NotificationCreator {
                     eventDataByEventTypeMap.forEach((eventType, eventData) -> {
                         try {
                             ColumnEventType columnEventType = ColumnEventType.from(eventType);
-                            String jsonString = objectMapper.writeValueAsString(eventData);
                             List<User> subscribedSavedUser = facade.getSubscribedUsers(columnEventType, eventData.get(0));
+                            List<String> processedData = facade.getProcessedData(columnEventType,eventData);
+                            String jsonString = objectMapper.writeValueAsString(processedData);
+
                             subscribedSavedUser
                                     .forEach(user -> {
                                         notifications.add(

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -22,12 +22,7 @@ public class NotificationConverter {
     // static을 하지 않으면 사용하는 객체를 생성할 때 facade를 계속 의존성 주입 해줘야함
     // 그런데 NotificationResponse Dto 클래스에 Facade 의존성 주입을 해주는 것이 클래스 목적성을 흐린다고 생각하여 해당 클래스를 만듦.
     // 따라서 처음에 facade를 static으로 선언 된 것을 필드 주입을 통해서 facade 인스턴스를 초기화
-    private static Facade facade;
 
-    @Autowired
-    private void setFacade(Facade facade) {
-        NotificationConverter.facade = facade;
-    }
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -48,28 +43,24 @@ public class NotificationConverter {
         String title = null;
         String content = null;
         String notificationImageUrl = null;
-        List<String> processedData;
         switch (columnEventType) {
             case RP_INSERT:
-                processedData = facade.rpInsert(data);
                 // List.of(billId, billRepProposer, billProposers, billName, partyImage) <-정당이미지
-                title = processedData.get(1) + " 의원";
-                content = processedData.get(2) + "이 '" + processedData.get(3) + "'을/를 발의했어요!";
-                notificationImageUrl = processedData.get(4);
+                title = data.get(1) + " 의원";
+                content = data.get(2) + "이 '" + data.get(3) + "'을/를 발의했어요!";
+                notificationImageUrl = data.get(4);
                 break;
             case BILL_STAGE_UPDATE:
                 // List.of("bill_id", "bill_name", "proposers", "stage", "partyImage") <-정당이미지
-                processedData = facade.updateBillStage(data);
-                title = processedData.get(1) + "(" + processedData.get(2) + ")";
-                content = "스크랩한 법안이 본회의에서 '"+processedData.get(3)+"'되었어요!";
-                notificationImageUrl = processedData.get(4);
+                title = data.get(1) + "(" + data.get(2) + ")";
+                content = "스크랩한 법안이 본회의에서 '"+data.get(3)+"'되었어요!";
+                notificationImageUrl = data.get(4);
                 break;
             case CONGRESSMAN_PARTY_UPDATE:
                 // List.of(congressmanId, partyName, congressmanName, partyImage); <-정당이미지
-                processedData = facade.updateCongressmanParty(data);
-                title = processedData.get(1);
-                content = "'"+processedData.get(2)+"'의원의 당적이 '"+processedData.get(1)+"'(으)로 변동했어요!";
-                notificationImageUrl = processedData.get(3);
+                title = data.get(1);
+                content = "'"+data.get(2)+"'의원의 당적이 '"+data.get(1)+"'(으)로 변동했어요!";
+                notificationImageUrl = data.get(3);
                 break;
         }
 


### PR DESCRIPTION
## 1.내용
기존의 알림에서는 사용자별로 알림을 내보낼때 각각 쿼리를 날렸다.
하지만 이럴경우, 같은 알림을 100명의 사람들에게 보냈을 때, 각 알림당 5번의 쿼리를 보내게 된다면
한가지 알림당 500번의 쿼리가 날라가게 된다.
따라서 알림을 생성할때 필요한 데이터를 모두 조회하여 미리 데이터베이스에 저장해두고
알림을 조회할때 미리 조회한 데이터를 조합해서 보내주는 방식으로 변경하였음.