### PR TITLE
nginx 설정 후 카카오 로그인 요청 서버도메인 변경

### DIFF
--- a/lawmaking/src/main/resources/application-prod.properties
+++ b/lawmaking/src/main/resources/application-prod.properties
@@ -11,4 +11,4 @@ spring.jpa.generate-ddl=false
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 #Kakao
-spring.security.oauth2.client.registration.kakao.redirect-uri = https://lawdigest.net/v1/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri = https://lawdigest.store/v1/login/oauth2/code/kakao


### PR DESCRIPTION
## 내용
서버도메인이 lawdigest.store로 바뀌어서 카카오 로그인 요청 도메인 변경이 필요하여 수정