### PR TITLE
[BE] mainfeed포함된 api를 GUEST로 호출 시, authentication 객체 null

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -51,8 +51,9 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer ì
                         .configurationSource(corsConfig.corsConfigurationSource()))
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers("/v1/**/user/**").hasRole("MEMBER")
-                        .anyRequest().authenticated())
+                        .requestMatchers("/v1/**/mainfeed/**").authenticated()
+                        .requestMatchers("/v1/**/user/**","/v1/**/logout/**").hasRole("MEMBER")
+                        .anyRequest().permitAll())
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(customAuthenticationEntryPoint())
                         .accessDeniedHandler(tokenAccessDeniedHandler))

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
@@ -37,43 +37,48 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain)  throws ServletException, IOException {
         try{
-            String tokenStr = HeaderUtil.getAccessToken(request);
-            AuthToken token = tokenProvider.convertAuthToken(tokenStr);
             //시큐리티컨텍스트홀더 초기화
             SecurityContextHolder.clearContext();
 
-            // 토큰이 없을 경우 게스트사용자 권한을 SecurityContext에 부여해주고
-            if( tokenStr == null || tokenStr.isEmpty() || (!request.getServletPath().contains("user") && !request.getServletPath().contains("logout"))){
-                setGuestAuthentication();
-            }
-            // 토큰이 있을 경우 검증을 해주고 검증이 되지 않으면 GUEST 권한을 주도록 하자.
-            else{
-                // token내용을 가지고 GUEST인지 MEMBER인지 검증함
-                var authentication = tokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            String tokenStr = HeaderUtil.getAccessToken(request);
+            AuthToken token = tokenProvider.convertAuthToken(tokenStr);
 
-            }
+            var authentication = tokenProvider.getAuthentication(token);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+
+
+            // 토큰이 없을 경우 게스트사용자 권한을 SecurityContext에 부여해주고
+
+
         }
         catch (ExpiredJwtException eje){
+            eje.printStackTrace();
             request.setAttribute("expiredJwtException", eje);
         }
         catch (SecurityException | MalformedJwtException | UnsupportedJwtException e) {
-            request.setAttribute("SecurityException", e);
-            setGuestAuthentication();
+            e.printStackTrace();
+            request.setAttribute("SecurityExceptionForJwt", e);
         }
         catch(IllegalArgumentException e){
+            request.setAttribute("IllegalArgumentException", e);
+            e.printStackTrace();
 
+        }
+        catch(Exception e){
+            request.setAttribute("Exception", e);
+            e.printStackTrace();
         }
 
         filterChain.doFilter(request, response);
 
     }
 
-    private void setGuestAuthentication() {
-        var guestAuthority = new SimpleGrantedAuthority("ROLE_GUEST");
-        Collection<? extends GrantedAuthority> authorities = Collections.singleton(guestAuthority);
-        UserDetails principal = new User("anonymous", "", authorities);
-        var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // 'user', 'mainfeed', 'logout'가 설정되지 않은 패스에 대해서는 setGuest로 고정
+        String path = request.getServletPath();
+        return !path.contains("/user")&&!path.contains("/mainfeed")&&!path.contains("/logout");
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/jwt/AuthToken.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/jwt/AuthToken.java
@@ -58,7 +58,7 @@ public class AuthToken {
 
 
     public boolean validate()  {
-        return this.getTokenClaims() != null;
+        return this.token != null && this.getTokenClaims() != null;
     }
 
     // ToDo(Exception 처리해야함)


### PR DESCRIPTION
## 1. 내용
user가 포함되지 않은 path에 대해서는 바로 GUEST 권한을 부여하여 authentication의 userDetails.getUsername()가 anonymous가 되었음.
그래서 user와 mainfeed와 logout을 포함한 path에 대해서 토큰을 확인하도록 하고, 시큐리티권한에서 mainfeed가 포함된 path의 권한을 authenticatated로 하여 GUEST권한에서도 동작하게끔 함. 그 외에 대해서는 permitAll을 부여하여 통과되도록 만듦.

## 2. 추가 논의 사항
사용자 정보가 있을때와 없을때 달라지는 api에 대해서 토큰검사를 하는게 맞지 않나 생각하여 위와 같이 구현.
토큰이 필요없어도 되는 api에서도 토큰검사를 하면 의미가 없지 않나 그런 생각을 하게 됨.