### PR TITLE
Fix(#Mainfeed-Performance) 메인피드 조회 API 성능 향상

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -8,7 +8,6 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 
@@ -18,6 +17,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Table(name = "Bill", indexes = @Index(name = "idx_bill_id_propose_date", columnList = "propose_date DESC"))
 public class Bill {
     @Id
     @Column(name = "bill_id")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -3,6 +3,7 @@ package com.everyones.lawmaking.repository;
 import com.everyones.lawmaking.domain.entity.Bill;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,15 +19,15 @@ public interface BillRepository extends JpaRepository<Bill, String> {
 
     // 단순한 법안 페이징으로 가져오기
     @Query("SELECT b FROM Bill b " +
-            "JOIN FETCH b.representativeProposer rp " +
             "ORDER BY b.proposeDate DESC, b.id DESC")
+    @EntityGraph(attributePaths = {"representativeProposer"})
     Slice<Bill> findByPage(Pageable pageable);
 
     // 단계 + 법안 페이징으로 가져오기
     @Query("SELECT b FROM Bill b " +
-            "JOIN FETCH b.representativeProposer rp " +
            "WHERE b.stage = :stage " +
             "ORDER BY b.proposeDate DESC, b.id DESC ")
+    @EntityGraph(attributePaths = {"representativeProposer"})
     Slice<Bill> findByPage(Pageable pageable, @Param("stage") String stage);
 
     // 특정 의원이 대표 발의한 법안들
@@ -81,7 +82,7 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Optional<Bill> findBillInfoById(String billId);
 
     // 피드 등 여러 법안들 가져오는 쿼리
-    @Query("SELECT b FROM Bill b " +
+    @Query("SELECT DISTINCT b FROM Bill b " +
             "JOIN FETCH b.representativeProposer rp " +
             "JOIN FETCH b.publicProposer bp " +
             "JOIN FETCH rp.congressman rpc " +

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -20,7 +20,7 @@ spring.datasource.username= ${DB_USERNAME}
 spring.datasource.password= ${DB_PASSWORD}
 
 # JPA Batch Size Config
-spring.jpa.properties.hibernate.default_batch_fetch_size=20
+spring.jpa.properties.hibernate.default_batch_fetch_size=500
 
 # app jwt token configurations
 app.auth.token-secret= ${TOKEN_SECRET}


### PR DESCRIPTION
## 내용
메인 피드 조회 시 API 성능 향상 2~3초에서 0.3~0.7초로 성능 향상

## 세부 사항

기존 메인 피드를 조회하기 위해서는 페이징 쿼리 + 법안 관련 데이터를 가져오기 위한 Fetch Join 쿼리로 총 2가지의 쿼리로 이루어져있다.

페이징 쿼리에서 성능 저하의 원인이 발생함.

### 쿼리 변경점
기존 쿼리
![image](https://github.com/LawDigest/Lawbag/assets/109566855/4faaedf4-0037-4b44-8555-73a358626833)

변경 쿼리
![image](https://github.com/LawDigest/Lawbag/assets/109566855/b15e6387-f2bb-4c22-8648-dbb5a6cb8a5e)

**기존 쿼리의 배경**
Bill과 RepresentativeProposer의 관계가 OneToOne이기 때문에, Bill을 조회할 때마다 RepresentativeProposer를 호출하는 쿼리를 자동으로 호출했기 때문에, 이를 방지하기 위해 FetchJoin을 활용하여 같이 가져왔는데 이 부분이 문제를 발생시켰다.
-> Fetch Join을 EntityGraph를 활용하여 RepresentativeProposer를 가져오는 방식으로 페이징 쿼리를 변경하였음.

**결과**
기존 메인피드 API호출이 2~3초에서 0.2초 ~ 0.7초로 바뀜

네트워크 비용을 고려하지 않고 어플리케이션 레이어 내에서 기존 페이징 쿼리는 무려 **0.9초가 걸렸고**, 변경된 쿼리는 2개의 쿼리를 합쳐도 **0.1초 이내로 처리 가능**했음.

### 기존 쿼리가 성능 저하를 발생시켰던 이유
작성 예정
