### PR TITLE
법안 검색 로직 변경

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -102,12 +102,13 @@ public interface BillRepository extends JpaRepository<Bill, String> {
 
     @Query(value = "select bill_id\n" +
             "from\n" +
-            "(select bill_id ,match(gpt_summary) against(concat('*',:keyword,'*') in boolean mode) as gpt_summary_rel,\n" +
-            "match(keyword) against(concat('*',:keyword,'*') in boolean mode) as keyword_rel,\n" +
-            "match(bill_name) against(concat('*',:keyword,'*') in boolean mode) as bill_name_rel\n" +
+            "(select bill_id ,match(bill_name) against(concat('*',:keyword,'*') in boolean mode) as bill_name_rel,\n" +
+            "match(brief_summary) against(concat('*',:keyword,'*') in boolean mode) as brief_summary_rel,\n" +
+            "match(gpt_summary) against(concat('*',:keyword,'*') in boolean mode) as gpt_summary_rel,\n" +
+            "match(summary) against(concat('*',:keyword,'*') in boolean mode) as summary_rel\n" +
             "from Bill) search\n" +
-            "where keyword_rel >0 or gpt_summary_rel>0 or bill_name_rel > 0\n" +
-            "order by keyword_rel desc, bill_name_rel desc, gpt_summary_rel desc"
+            "where bill_name_rel >0 or brief_summary_rel>0 or gpt_summary_rel>0 or summary_rel > 0\n" +
+            "order by bill_name_rel desc, brief_summary_rel desc, gpt_summary_rel desc, summary_rel desc ;"
             , nativeQuery = true)
     Slice<String> findBillByKeyword(Pageable pageable,@Param("keyword") String keyword);
 


### PR DESCRIPTION
## 내용
데이터 자동화에서는 ai 모델의 키워드 추출부분에서 비용이슈로 키워드를 지속적으로 업데이트 하지 못한다고 판단되어,
법안 검색시 키워드를 제외하고 법안 이름(billName), 요약(summary), gpt 요약(gptSummary), 간단한 요약(briefSummary) 네가지 컬럼을 이용하는 로직 변경