### PR TITLE
토큰 재발급 권한 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -342,7 +342,6 @@ public class Facade {
     }
 
     public void reissueToken(HttpServletRequest httpServletRequest,HttpServletResponse httpServletResponse) throws Exception {
-//        return authService.reissueToken(httpServletRequest, httpServletResponse);
         authService.reissueToken(httpServletRequest, httpServletResponse);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer ì
                         .configurationSource(corsConfig.corsConfigurationSource()))
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                        .requestMatchers("/v1/auth/reissue/token").permitAll()
                         .requestMatchers("/v1/**/user/**","/v1/**/logout/**").hasRole("MEMBER")
                         .anyRequest().authenticated())
                 .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
@@ -36,6 +36,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain)  throws ServletException, IOException {
+        var path = request.getRequestURI();
+        if (path.equals("/v1/auth/reissue/token")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         try{
             //시큐리티컨텍스트홀더 초기화
             SecurityContextHolder.clearContext();

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/TokenAuthenticationFilter.java
@@ -13,17 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 
 @Slf4j
 @RequiredArgsConstructor


### PR DESCRIPTION
## 내용
토큰 재발급 요청시에 토큰검사를 하였고 권한이 없으니 MEMBER권한에 걸려있어서 요청이 되지 않았음.
따라서 재발급 요청시에 토큰검사를 생략하고 권한을 허용해줌.

나머지는 주석해제 및 사용하지 않는 임포트 제거