### PR TITLE
법안 검색에서 변수 네이밍 규칙 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/SearchBillResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/SearchBillResponse.java
@@ -1,6 +1,8 @@
 package com.everyones.lawmaking.common.dto.response;
 
 import com.everyones.lawmaking.common.dto.BillDto;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +12,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SearchBillResponse {
     private List<BillDto> searchResponse;
 


### PR DESCRIPTION
## 내용
프론트에 반환된 값에서 searchResponse가 카멜케이스로 되어있었음. 따라서 스네이크케이스로 변환함.