### PR TITLE
[BE] 법안과 대표발의자 one To Many 관계로 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDto.java
@@ -4,7 +4,10 @@ package com.everyones.lawmaking.common.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -20,7 +23,7 @@ public class BillDto {
     private BillInfoDto billInfoDto;
 
     @NotNull
-    private RepresentativeProposerDto representativeProposerDto;
+    private List<RepresentativeProposerDto> representativeProposerDtoList;
 
     @NotNull
     private List<PublicProposerDto> publicProposerDtoList;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillDetailResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillDetailResponse.java
@@ -16,12 +16,8 @@ public class BillDetailResponse extends BillDto {
     private List<SimilarBill> similarBills;
 
 
-    public BillDetailResponse(@NotNull BillInfoDto billInfoDto, @NotNull RepresentativeProposerDto representativeProposerDto, @NotNull List<PublicProposerDto> publicProposerDtoList, @NotNull Boolean isBookMarked) {
+    public BillDetailResponse(@NotNull BillInfoDto billInfoDto, @NotNull List<RepresentativeProposerDto> representativeProposerDto, @NotNull List<PublicProposerDto> publicProposerDtoList, @NotNull Boolean isBookMarked) {
         super(billInfoDto, representativeProposerDto, publicProposerDtoList, isBookMarked);
-    }
-    public BillDetailResponse(@NotNull BillInfoDto billInfoDto, @NotNull RepresentativeProposerDto representativeProposerDto, @NotNull List<PublicProposerDto> publicProposerDtoList, Boolean isBookMarked,List<SimilarBill> similarBills) {
-        super(billInfoDto, representativeProposerDto, publicProposerDtoList, isBookMarked);
-        this.similarBills = similarBills;
     }
 
     public void setSimilarBills(List<SimilarBill> similarBills) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -28,7 +28,7 @@ public class NotificationResponse {
     private String target;
 
     @NotNull
-    private String notificationImageUrl;
+    private List<String> notificationImageUrlList;
 
     @NotNull
     private String type;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -8,7 +8,9 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 @Entity
@@ -26,6 +28,11 @@ public class Bill {
     @Column(name = "bill_number", unique = true)
     private int billNumber;
 
+    // 법안의 제안시점 정당 데이터용으로 partyId 필요
+    @Column(name = "partyIdList")
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<Long> partyIdList;
+
     @NotNull
     @Column(name = "assembly_number")
     private int assemblyNumber;
@@ -39,8 +46,8 @@ public class Bill {
     @OneToMany(mappedBy = "bill")
     private List<BillProposer> publicProposer;
 
-    @OneToOne(mappedBy = "bill", fetch = FetchType.LAZY)
-    private RepresentativeProposer representativeProposer;
+    @OneToMany(mappedBy = "bill", fetch = FetchType.LAZY)
+    private Set<RepresentativeProposer> representativeProposer = new HashSet<>();
 
     @OneToMany(mappedBy = "bill")
     private List<BillLike> billLike;
@@ -69,6 +76,10 @@ public class Bill {
 
     @Column(name ="bill_link")
     private String billLink;
+
+    @Column(name ="age")
+    @ColumnDefault("0")
+    private int age;
 
     @ColumnDefault("0")
     private int viewCount;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -5,12 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 @Entity
@@ -47,7 +46,7 @@ public class Bill {
     private List<BillProposer> publicProposer;
 
     @OneToMany(mappedBy = "bill", fetch = FetchType.LAZY)
-    private Set<RepresentativeProposer> representativeProposer = new HashSet<>();
+    private List<RepresentativeProposer> representativeProposer;
 
     @OneToMany(mappedBy = "bill")
     private List<BillLike> billLike;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -6,18 +6,19 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
-import java.util.ArrayList;
 import java.util.List;
 
 
 @Entity
 @Data
 @Builder
-@ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Congressman {
+    @Version
+    private Long version;
+
     @Id
     @Column(name = "congressman_id")
     private String id;
@@ -68,4 +69,13 @@ public class Congressman {
     @ColumnDefault("22")
     @Column(name = "assembly_number")
     private int assemblyNumber;
+
+    @Override
+    public String toString() {
+        return "Congressman{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -17,6 +17,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Party extends BaseEntity{
+    @Version
+    private Long version;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "party_id")
@@ -41,26 +44,46 @@ public class Party extends BaseEntity{
     private String websiteUrl;
 
     @Column(name = "follow_count")
-    private int followCount;
+    private int followCount = 0;
 
     @ColumnDefault("0")
+    @Builder.Default
     @Column(name = "proportional_congressman_count")
-    private int proportionalCongressmanCount;
+    private int proportionalCongressmanCount = 0;
 
     @ColumnDefault("0")
+    @Builder.Default
     @Column(name = "district_congressman_count")
-    private int districtCongressmanCount;
+    private int districtCongressmanCount = 0;
 
     @ColumnDefault("0")
+    @Builder.Default
     @Column(name = "total_bill_count")
-    private int totalBillCount;
+    private int totalBillCount = 0;
 
     @ColumnDefault("0")
+    @Builder.Default
     @Column(name = "representative_bill_count")
-    private int representativeBillCount;
+    private int representativeBillCount = 0;
 
     @ColumnDefault("0")
+    @Builder.Default
     @Column(name = "public_bill_count")
-    private int publicBillCount;
+    private int publicBillCount = 0;
+
+    @Override
+    public String toString() {
+        return "Party{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", districtCongressmanCount=" + districtCongressmanCount +
+                ", proportionalCongressmanCount=" + proportionalCongressmanCount +
+
+                '}';
+    }
+
+
+
+
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/RepresentativeProposer.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/RepresentativeProposer.java
@@ -14,7 +14,7 @@ public class RepresentativeProposer {
     @Column(name = "representative_proposer_id")
     private long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bill_id")
     private Bill bill;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -213,9 +213,9 @@ public class Facade {
         return List.of(billId, billRepProposer, billProposers, billName,congressman.getParty().getPartyImageUrl());
     }
     public List<String> updateBillStage(List<String> raw) {
-        var party = partyService.getPartyByBillId(raw.get(0));
+        var partyImageList = partyService.getPartyByBillId(raw.get(0));
 
-        return Stream.concat(raw.stream(), Stream.of(party.getPartyImageUrl()))
+        return Stream.concat(raw.stream(), partyImageList.stream())
                 .toList();
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
@@ -5,14 +5,12 @@ import com.everyones.lawmaking.domain.entity.Notification;
 import com.everyones.lawmaking.domain.entity.User;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.error.CommonException;
-import com.everyones.lawmaking.global.error.CustomException;
-import com.everyones.lawmaking.global.ResponseCode;
-import com.everyones.lawmaking.global.error.ErrorCode;
 import com.everyones.lawmaking.repository.NotificationRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +24,7 @@ public class NotificationCreator {
     private final Facade facade;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    @Transactional
     public void createNotification(List<Map<String, List<String>>> filteredValuesByRows) {
         List<Notification> notifications = new ArrayList<>();
         filteredValuesByRows.forEach((eventDataByEventTypeMap) -> {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.sql.*;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,6 +52,11 @@ public class TableEventListener {
     private final Map<Long, TableMapInfo> relatedTableMapEvents = new HashMap<>();
 
     private final NotificationCreator notificationCreator;
+
+    @Bean
+    public ExecutorService executorService() {
+        return Executors.newFixedThreadPool(10); // 스레드 풀 크기 10으로 설정
+    }
 
     /**
      * 테이블별 (컬럼네임,컬럼 인덱스) 정보 가져오는 메서드
@@ -252,16 +259,15 @@ public class TableEventListener {
                 }
             }
         });
+//        executorService().submit(() -> {
+//            try {
+//                logClient.connect();
+//            } catch (IOException e) {
+//                e.printStackTrace();
+//            }
+//        });
 
-        Thread thread = new Thread(() -> {
-            try {
-                logClient.connect();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        });
 
-        thread.start();
         return logClient;
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -4,15 +4,13 @@ import com.everyones.lawmaking.common.dto.response.NotificationResponse;
 import com.everyones.lawmaking.domain.entity.ColumnEventType;
 import com.everyones.lawmaking.domain.entity.Notification;
 import com.everyones.lawmaking.global.error.CommonException;
-import com.everyones.lawmaking.global.error.CustomException;
-import com.everyones.lawmaking.global.error.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 
-import java.text.ParseException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -46,25 +44,25 @@ public class NotificationConverter {
         String target = data.get(0);
         String title = null;
         String content = null;
-        String notificationImageUrl = null;
+        List<String> notificationImageUrlList = new ArrayList<>();
         switch (columnEventType) {
             case RP_INSERT:
                 // List.of(billId, billRepProposer, billProposers, billName, partyImage) <-정당이미지
                 title = data.get(1) + " 의원";
                 content = data.get(2) + "이 '" + data.get(3) + "'을/를 발의했어요!";
-                notificationImageUrl = data.get(4);
+                notificationImageUrlList.add(data.get(4));
                 break;
             case BILL_STAGE_UPDATE:
                 // List.of("bill_id", "bill_name", "proposers", "stage", "partyImage") <-정당이미지
                 title = data.get(1) + "(" + data.get(2) + ")";
                 content = "스크랩한 법안이 본회의에서 '"+data.get(3)+"'되었어요!";
-                notificationImageUrl = data.get(4);
+                notificationImageUrlList.addAll(data.subList(4, data.size()));
                 break;
             case CONGRESSMAN_PARTY_UPDATE:
                 // List.of(congressmanId, partyName, congressmanName, partyImage); <-정당이미지
                 title = data.get(1);
                 content = "'"+data.get(2)+"'의원의 당적이 '"+data.get(1)+"'(으)로 변동했어요!";
-                notificationImageUrl = data.get(3);
+                notificationImageUrlList.add(data.get(4));
                 break;
         }
 
@@ -80,7 +78,7 @@ public class NotificationConverter {
                 .type(type)
                 // 알림으로 이동할 대상 id값
                 .target(target)
-                .notificationImageUrl(notificationImageUrl)
+                .notificationImageUrlList(notificationImageUrlList)
                 .title(title)
                 .content(content)
                 .createdDate(createdDate)

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -63,7 +63,7 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findByUserId(Pageable pageable, @Param("userId") long userId);
 
     // 단일 법안과 관련된 정보 가져오는 쿼리
-    @Query("SELECT  b FROM Bill b " +
+    @Query("SELECT distinct b FROM Bill b " +
             "JOIN FETCH b.representativeProposer rp " +
             "JOIN FETCH rp.congressman rpc " +
             "JOIN FETCH rpc.party rpp " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -5,11 +5,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +68,7 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findByUserId(Pageable pageable, @Param("userId") long userId);
 
     // 단일 법안과 관련된 정보 가져오는 쿼리
-    @Query("SELECT b FROM Bill b " +
+    @Query("SELECT distinct b FROM Bill b " +
             "JOIN FETCH b.representativeProposer rp " +
             "JOIN FETCH b.publicProposer bp " +
             "JOIN FETCH rp.congressman rpc " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -3,7 +3,6 @@ package com.everyones.lawmaking.repository;
 import com.everyones.lawmaking.domain.entity.Bill;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,14 +17,12 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     // 단순한 법안 페이징으로 가져오기
     @Query("SELECT b FROM Bill b " +
             "ORDER BY b.proposeDate DESC, b.id DESC")
-    @EntityGraph(attributePaths = {"representativeProposer"})
     Slice<Bill> findByPage(Pageable pageable);
 
     // 단계 + 법안 페이징으로 가져오기
     @Query("SELECT b FROM Bill b " +
            "WHERE b.stage = :stage " +
             "ORDER BY b.proposeDate DESC, b.id DESC ")
-    @EntityGraph(attributePaths = {"representativeProposer"})
     Slice<Bill> findByPage(Pageable pageable, @Param("stage") String stage);
 
     // 특정 의원이 대표 발의한 법안들
@@ -37,7 +34,6 @@ public interface BillRepository extends JpaRepository<Bill, String> {
 
     // 특정의원이 공동 발의한 법안들
     @Query("SELECT b FROM Bill b " +
-            "JOIN FETCH b.representativeProposer rp " +
             "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.id = :congressmanId)")
     Slice<Bill> findBillByPublicProposer(String congressmanId, Pageable pageable);
 
@@ -53,7 +49,6 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     // 정당 소속 의원들이 공동 발의한 법안
     // TODO: 쿼리 개선 필요
     @Query("SELECT b FROM Bill b " +
-           "JOIN FETCH b.representativeProposer rp " +
             "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.party.id = :partyId) " +
             "ORDER BY b.proposeDate DESC, b.id DESC")
     Slice<Bill> findPublicBillsByParty(Pageable pageable, @Param("partyId") long partyId);
@@ -68,13 +63,10 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findByUserId(Pageable pageable, @Param("userId") long userId);
 
     // 단일 법안과 관련된 정보 가져오는 쿼리
-    @Query("SELECT distinct b FROM Bill b " +
+    @Query("SELECT  b FROM Bill b " +
             "JOIN FETCH b.representativeProposer rp " +
-            "JOIN FETCH b.publicProposer bp " +
             "JOIN FETCH rp.congressman rpc " +
-            "JOIN FETCH bp.congressman bpc " +
             "JOIN FETCH rpc.party rpp " +
-            "JOIN FETCH bpc.party bpp " +
             "WHERE b.id = :billId "
     )
     Optional<Bill> findBillInfoById(String billId);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
@@ -32,12 +32,14 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             "FROM ProportionalCandidate pc ")
     Slice<Party> findProportionalParty(Pageable pageable);
 
-    @Query("SELECT distinct p " +
+    @Query("SELECT distinct p.partyImageUrl " +
             "from Party p " +
-            "join Congressman c on c.party.id = p.id " +
-            "join RepresentativeProposer rp on rp.congressman.id =c.id " +
+            "join Congressman rc on rc.party.id = p.id " +
+            "join RepresentativeProposer rp on rp.congressman.id =rc.id " +
+            "join Congressman pc on pc.party.id = p.id " +
+            "join BillProposer pp on pp.congressman.id =pc.id " +
             "where rp.bill.id =:billId")
-    Optional<Party> findPartyByBillId(@Param("billId") String billId);
+    List<String> findPartyByBillId(@Param("billId") String billId);
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
@@ -34,10 +34,8 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     @Query("SELECT distinct p.partyImageUrl " +
             "from Party p " +
-            "join Congressman rc on rc.party.id = p.id " +
-            "join RepresentativeProposer rp on rp.congressman.id =rc.id " +
-            "join Congressman pc on pc.party.id = p.id " +
-            "join BillProposer pp on pp.congressman.id =pc.id " +
+            "join Congressman c on c.party.id = p.id " +
+            "join RepresentativeProposer rp on rp.congressman.id =c.id " +
             "where rp.bill.id =:billId")
     List<String> findPartyByBillId(@Param("billId") String billId);
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -7,7 +7,6 @@ import com.everyones.lawmaking.common.dto.response.BillViewCountResponse;
 import com.everyones.lawmaking.common.dto.response.PaginationResponse;
 import com.everyones.lawmaking.domain.entity.Bill;
 import com.everyones.lawmaking.global.error.BillException;
-import com.everyones.lawmaking.global.util.AuthenticationUtil;
 import com.everyones.lawmaking.repository.BillRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -135,8 +134,9 @@ public class BillService {
         var billInfoDto = BillInfoDto.from(bill);
 
         // Representative Entity
-        var representativeProposerDto = RepresentativeProposerDto.from(bill.getRepresentativeProposer());
-
+        var representativeProposerDto = bill.getRepresentativeProposer().stream()
+                .map(RepresentativeProposerDto::from)
+                .toList();
         // PublicProposer Entity
         var publicProposerDtoList = bill.getPublicProposer().stream()
                 .map(PublicProposerDto::from)
@@ -144,7 +144,7 @@ public class BillService {
 
         return BillDto.builder()
                 .billInfoDto(billInfoDto)
-                .representativeProposerDto(representativeProposerDto)
+                .representativeProposerDtoList(representativeProposerDto)
                 .publicProposerDtoList(publicProposerDtoList)
                 .isBookMark(false)
                 .build();
@@ -159,7 +159,7 @@ public class BillService {
         var billInfoDto = BillDetailInfo.from(bill);
 
         // Representative Entity
-        var representativeProposer = bill.getRepresentativeProposer();
+        var representativeProposers = bill.getRepresentativeProposer();
 
         // PublicProposer Entity
         var publicProposers = bill.getPublicProposer();
@@ -168,9 +168,12 @@ public class BillService {
                 .map(PublicProposerDto::from)
                 .toList();
 
-        var representativeProposerDto = RepresentativeProposerDto.from(representativeProposer);
 
-        return new BillDetailResponse(billInfoDto, representativeProposerDto, publicProposerDtoList, false);
+        var representativeProposerDtoList = representativeProposers.stream()
+                .map(RepresentativeProposerDto::from)
+                .toList();
+
+        return new BillDetailResponse(billInfoDto, representativeProposerDtoList, publicProposerDtoList, false);
     }
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
@@ -76,9 +76,12 @@ public class PartyService {
         return ProportionalPartyResponse.of(party,candidateNumber);
     }
 
-    public Party getPartyByBillId(String billId) {
-        return partyRepository.findPartyByBillId(billId)
-                .orElseThrow(() -> new BillException.BillNotFound(Map.of("billId", billId)));
+    public List<String> getPartyByBillId(String billId) {
+        List<String> partyImageList = partyRepository.findPartyByBillId(billId);
+        if (partyImageList.isEmpty()) {
+            throw new PartyException.PartyNotFound(Map.of("billId", billId));
+        }
+        return partyImageList;
 
     }
 

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -20,7 +20,7 @@ spring.datasource.username= ${DB_USERNAME}
 spring.datasource.password= ${DB_PASSWORD}
 
 # JPA Batch Size Config
-spring.jpa.properties.hibernate.default_batch_fetch_size=300
+spring.jpa.properties.hibernate.default_batch_fetch_size=500
 
 # app jwt token configurations
 app.auth.token-secret= ${TOKEN_SECRET}

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -20,7 +20,7 @@ spring.datasource.username= ${DB_USERNAME}
 spring.datasource.password= ${DB_PASSWORD}
 
 # JPA Batch Size Config
-spring.jpa.properties.hibernate.default_batch_fetch_size=500
+spring.jpa.properties.hibernate.default_batch_fetch_size=300
 
 # app jwt token configurations
 app.auth.token-secret= ${TOKEN_SECRET}


### PR DESCRIPTION
## 내용
https://www.newspet.co.kr/news/articleView.html?idxno=7566
2024년 1월부로 법안 발의시 대표발의자 여러 의원을 기재함에 따라
법안과 대표발의자 관계를 One To Many로 바꾸면서
One To One관계를 가정하고 개발했던 메서드를 수정함.
