### PR TITLE
Fix(#Delete-Follow) 법안 스크랩, 정당 팔로우, 의원 팔로우 등의 기능에서 테이블을 업데이트하는 방식에서 생성/삭제 방식으로 변경

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
@@ -37,12 +37,13 @@ public class BillInfoDto {
         this.summary = bill.getSummary();
         this.gptSummary = bill.getGptSummary();
         this.viewCount = bill.getViewCount();
-        this.billLikeCount = bill.getLikeCount();
+        this.billLikeCount = bill.getBillLike().size();
         this.billStage = bill.getStage();
         this.briefSummary = bill.getBriefSummary();
     }
 
     public static BillInfoDto from(Bill bill) {
+        var billLikeCount = bill.getBillLike().size();
         return BillInfoDto.builder()
                 .billId(bill.getId())
                 .billName(bill.getBillName())
@@ -50,7 +51,7 @@ public class BillInfoDto {
                 .summary(bill.getSummary())
                 .gptSummary(bill.getGptSummary())
                 .viewCount(bill.getViewCount())
-                .billLikeCount(bill.getLikeCount())
+                .billLikeCount(billLikeCount)
                 .billStage(bill.getStage())
                 .briefSummary(bill.getBriefSummary())
                 .build();

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillLikeResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillLikeResponse.java
@@ -1,5 +1,6 @@
 package com.everyones.lawmaking.common.dto.response;
 
+import com.everyones.lawmaking.domain.entity.Bill;
 import com.everyones.lawmaking.domain.entity.BillLike;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -21,11 +22,10 @@ public class BillLikeResponse {
     private boolean likeChecked;
 
 
-    public static BillLikeResponse from(BillLike billLike) {
+    public static BillLikeResponse from(boolean likeChecked) {
         return BillLikeResponse.builder()
-                .billId(billLike.getBill().getId())
-                .likeChecked(billLike.isLikeChecked())
+                .likeChecked(likeChecked)
                 .build();
-
     }
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
@@ -15,15 +15,11 @@ import lombok.Getter;
 public class CongressmanLikeResponse {
 
     @NotNull
-    private String congressmanId;
-
-    @NotNull
     private boolean likeChecked;
 
-    public static CongressmanLikeResponse from(CongressManLike congressmanLike){
+    public static CongressmanLikeResponse from(boolean likeChecked){
         return CongressmanLikeResponse.builder()
-                .congressmanId(congressmanLike.getCongressman().getId())
-                .likeChecked(congressmanLike.isLikeChecked())
+                .likeChecked(likeChecked)
                 .build();
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/CongressmanLikeResponse.java
@@ -1,6 +1,5 @@
 package com.everyones.lawmaking.common.dto.response;
 
-import com.everyones.lawmaking.domain.entity.CongressManLike;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyDetailResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyDetailResponse.java
@@ -34,8 +34,9 @@ public class PartyDetailResponse {
     @NotNull
     private String websiteUrl;
 
-    // TODO: isFollowed의 경우, User를 거치는 경우와 안 거치는 경우를 나눠서 해야함.
+
     public static PartyDetailResponse from(Party party) {
+        var partyFollow = party.getPartyFollow();
         return PartyDetailResponse.builder()
                 .partyId(party.getId())
                 .partyName(party.getName())
@@ -45,7 +46,7 @@ public class PartyDetailResponse {
                 .districtCongressmanCount(party.getDistrictCongressmanCount())
                 .representativeBillCount(party.getRepresentativeBillCount())
                 .publicBillCount(party.getPublicBillCount())
-                .followCount(party.getFollowCount())
+                .followCount(partyFollow.size())
                 .isFollowed(false)
                 .build();
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyFollowResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyFollowResponse.java
@@ -1,10 +1,7 @@
 package com.everyones.lawmaking.common.dto.response;
 
-import com.everyones.lawmaking.domain.entity.CongressManLike;
-import com.everyones.lawmaking.domain.entity.PartyFollow;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +12,11 @@ import lombok.Getter;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PartyFollowResponse {
 
-    private long partyId;
-
     private boolean followChecked;
 
-    public static PartyFollowResponse from(PartyFollow partyFollow){
+    public static PartyFollowResponse from(boolean followChecked){
         return PartyFollowResponse.builder()
-                .partyId(partyFollow.getParty().getId())
-                .followChecked(partyFollow.isFollowChecked())
+                .followChecked(followChecked)
                 .build();
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -83,7 +83,4 @@ public class Bill {
     @ColumnDefault("0")
     private int viewCount;
 
-    @ColumnDefault("0")
-    private int likeCount;
-
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillLike.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BillLike.java
@@ -26,8 +26,4 @@ public class BillLike extends BaseEntity {
     @JoinColumn(name = "bill_id")
     private Bill bill;
 
-    @NotNull
-    @Column(name = "like_checked")
-    private boolean likeChecked;
-
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/CongressManLike.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/CongressManLike.java
@@ -24,9 +24,5 @@ public class CongressManLike {
     @JoinColumn(name = "congress_man_id")
     private Congressman congressman;
 
-    @NotNull
-    @Column(name = "like_checked")
-    private boolean likeChecked;
-
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -63,9 +63,6 @@ public class Congressman {
     @Column(name = "congressman_image_url")
     private String congressmanImageUrl;
 
-    @ColumnDefault("0")
-    private int likeCount;
-
     @ColumnDefault("22")
     @Column(name = "assembly_number")
     private int assemblyNumber;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -36,7 +36,7 @@ public class Congressman {
     private List<RepresentativeProposer> representativeProposer;
 
     @OneToMany(mappedBy = "congressman")
-    private List<CongressManLike> congressManLike;
+    private List<CongressmanLike> congressmanLike;
 
     @Column(name = "elect_sort")
     private String electSort;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/CongressmanLike.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/CongressmanLike.java
@@ -1,7 +1,6 @@
 package com.everyones.lawmaking.domain.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Entity
@@ -9,11 +8,12 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CongressManLike {
+@Table(uniqueConstraints = @UniqueConstraint(name = "ix_congressman_like_unique", columnNames = {"user_id", "congressman_id"}))
+public class CongressmanLike extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "congress_man_like_id")
+    @Column(name = "congressman_like_id")
     private long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -21,7 +21,7 @@ public class CongressManLike {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "congress_man_id")
+    @JoinColumn(name = "congressman_id")
     private Congressman congressman;
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -43,9 +43,6 @@ public class Party extends BaseEntity{
     @Column(name = "website_url")
     private String websiteUrl;
 
-    @Column(name = "follow_count")
-    private int followCount = 0;
-
     @ColumnDefault("0")
     @Builder.Default
     @Column(name = "proportional_congressman_count")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/PartyFollow.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/PartyFollow.java
@@ -13,7 +13,8 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PartyFollow {
+@Table(uniqueConstraints = @UniqueConstraint(name = "ix_party_follow_unique", columnNames = {"user_id", "party_id"}))
+public class PartyFollow extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,9 +28,5 @@ public class PartyFollow {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id")
     private Party party;
-
-    @NotNull
-    @Column(name = "follow_checked")
-    private boolean followChecked;
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
     private AuthInfo authInfo;
 
     @OneToMany(mappedBy = "user")
-    private List<CongressManLike> congressManLike;
+    private List<CongressmanLike> congressManLike;
 
     @OneToMany(mappedBy = "user")
     private List<PartyFollow> partyFollow;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -118,7 +118,6 @@ public class Facade {
     public BillLikeResponse likeBill(long userId, String billId, boolean likeChecked) {
         var user = userService.findById(userId);
         var bill = billService.findById(billId);
-        billService.updateBillLikeCount(bill, likeChecked);
         return likeService.likeBill(user, bill, likeChecked);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -126,7 +126,6 @@ public class Facade {
     public CongressmanLikeResponse likeCongressman(long userId, String congressmanId, boolean likeChecked) {
         var user = userService.findById(userId);
         var congressman = congressmanService.findById(congressmanId);
-        congressmanService.updateCongressmanLikeCount(congressman, likeChecked);
         return likeService.likeCongressman(user, congressman, likeChecked);
     }
 
@@ -135,7 +134,6 @@ public class Facade {
     public PartyFollowResponse followParty(long userId, long partyId, boolean followChecked) {
         var user = userService.findById(userId);
         var party = partyService.findById(partyId);
-        partyService.updatePartyFollowCount(party, followChecked);
         return likeService.followParty(user, party, followChecked);
     }
 
@@ -199,7 +197,7 @@ public class Facade {
     }
 
     // 알림 데이터를 각 테이블에 해당하는 실제 데이터로 변환 (ex : bill_id
-
+    // TODO: 컨벤션에 맞게 메소드명 변경 필요
     public List<String> rpInsert(List<String> raw) {
         var congressman = congressmanService.findById(raw.get(0));
         var billRepProposer = congressman.getName();

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -16,6 +16,7 @@ public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
             "where bl.bill.id = :billId AND bl.user.id = :userId")
     Optional<BillLike> findByUserIdAndBillId(@Param("userId") long userId, @Param("billId") String billId);
 
+//    void deleteById(@Param("billLikeId") long billLikeId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -1,6 +1,6 @@
 package com.everyones.lawmaking.repository;
 
-import com.everyones.lawmaking.domain.entity.CongressManLike;
+import com.everyones.lawmaking.domain.entity.CongressmanLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface CongressmanLikeRepository extends JpaRepository<CongressManLike, Long> {
+public interface CongressmanLikeRepository extends JpaRepository<CongressmanLike, Long> {
 
-    @Query("SELECT cl FROM CongressManLike cl " +
+    @Query("SELECT cl FROM CongressmanLike cl " +
             "WHERE cl.user.id = :userId AND cl.congressman.id = :congressmanId")
-    Optional<CongressManLike> findByUserIdAndCongressmanId(@Param("userId")long userId, @Param("congressmanId")String congressmanId);
+    Optional<CongressmanLike> findByUserIdAndCongressmanId(@Param("userId")long userId, @Param("congressmanId")String congressmanId);
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
@@ -18,8 +18,8 @@ public interface CongressmanRepository extends JpaRepository<Congressman, String
     Optional<Congressman> findByIdWithParty(@Param("congressmanId") String congressmanId);
 
     @Query("SELECT c FROM Congressman c JOIN FETCH c.party " +
-            "JOIN c.congressManLike cl " +
-            "WHERE cl.user.id = :userId and cl.likeChecked = true ")
+            "JOIN c.congressmanLike cl " +
+            "WHERE cl.user.id = :userId")
     List<Congressman> findLikingCongressmanByUserId(@Param("userId") long userId);
 
     @Query("SELECT c FROM Congressman c " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyFollowRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyFollowRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 public interface PartyFollowRepository extends JpaRepository<PartyFollow, Long> {
 
     @Query("select pf from PartyFollow pf " +
-            "where pf.party.id = :partyId AND pf.user.id = :userId")
+            "where pf.party.id = :partyId AND pf.user.id = :userId ")
     Optional<PartyFollow> findByUserIdAndPartyId(@Param("userId") long userId, @Param("partyId") long partyId);
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
@@ -21,7 +21,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     @Query("SELECT p FROM Party p " +
             "JOIN p.partyFollow pf " +
-            "WHERE pf.user.id = :userId and pf.followChecked = true ")
+            "WHERE pf.user.id = :userId")
     List<Party> findFollowingPartyByUserId(@Param("userId") long userId);
 
     @Query("SELECT p FROM Party p " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
@@ -26,7 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserBySocialIdAndProvider(@Param("socialId") String socialId, @Param("provider") Provider provider);
 
 
-    @Query("SELECT cl.user FROM CongressManLike cl " +
+    @Query("SELECT cl.user FROM CongressmanLike cl " +
             "WHERE cl.congressman.id = :congressmanId")
     List<User> findAllByCongressmanId(@Param("congressmanId") String congressmanId);
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -113,7 +113,6 @@ public class BillService {
                 .map(this::getBillInfoFrom)
                 .toList();
 
-
         return BillListResponse.builder()
                 .paginationResponse(pagination)
                 .billList(billInfoList)

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -120,13 +120,6 @@ public class BillService {
                 .build();
     }
 
-
-    public void updateBillLikeCount(Bill bill, boolean likeChecked) {
-        var likeCount = likeChecked ? bill.getLikeCount() + 1 : bill.getLikeCount() - 1;
-        bill.setLikeCount(likeCount);
-        billRepository.save(bill);
-    }
-
     // 메인피드 등 법안들의 리스트를 반환할 때 사용
     private BillDto getBillInfoFrom(Bill bill) {
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
@@ -44,14 +44,6 @@ public class CongressmanService {
         return PartyCongressmanResponse.of(congresssmanList, pagination);
     }
 
-    @Transactional
-    public void updateCongressmanLikeCount(Congressman congressman, boolean likeChecked) {
-
-        var likeCount = likeChecked ? congressman.getLikeCount() + 1 : congressman.getLikeCount() - 1;
-        congressman.setLikeCount(likeCount);
-        congressmanRepository.save(congressman);
-    }
-
     public List<LikingCongressmanResponse> getLikingCongressman(long userId){
         var likingCongressman = congressmanRepository.findLikingCongressmanByUserId(userId);
         return likingCongressman.stream()

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -1,7 +1,6 @@
 package com.everyones.lawmaking.service;
 
 import com.everyones.lawmaking.common.dto.response.BillLikeResponse;
-import com.everyones.lawmaking.common.dto.response.BillListResponse;
 import com.everyones.lawmaking.common.dto.response.CongressmanLikeResponse;
 import com.everyones.lawmaking.common.dto.response.PartyFollowResponse;
 import com.everyones.lawmaking.domain.entity.*;
@@ -29,16 +28,16 @@ public class LikeService {
 
     public Boolean getCongressmanLike(String congressmanId, long userId) {
         var congressmanLike = congressmanLikeRepository.findByUserIdAndCongressmanId(userId, congressmanId);
-        return congressmanLike.map(CongressManLike::isLikeChecked).orElse(false);
+        return congressmanLike.isPresent();
     }
     public Boolean getFollowParty(long partyId, long userId) {
         var partyFollow = partyFollowRepository.findByUserIdAndPartyId(userId,partyId);
-        return partyFollow.map(PartyFollow::isFollowChecked).orElse(false);
+        return partyFollow.isPresent();
     }
 
     public Boolean getBillLikeChecked(String billId, long userId) {
         var billLike = billLikeRepository.findByUserIdAndBillId(userId, billId);
-        return billLike.map(BillLike::isLikeChecked).orElse(false);
+        return billLike.isPresent();
     }
 
     public BillLikeResponse likeBill(User user, Bill bill, boolean likeChecked) {
@@ -73,33 +72,36 @@ public class LikeService {
 
     public PartyFollowResponse followParty(User user, Party party, boolean followChecked) {
         var partyFollow = partyFollowRepository.findByUserIdAndPartyId(user.getId(), party.getId());
+        if (partyFollow.isPresent()) {
+            if (followChecked) {
+                throw new LikeException.UpdateParameterException(Map.of("likeChecked", Boolean.toString(followChecked)));
+            }
+            return deletePartyFollow(partyFollow.get());
+        }
+        if(!followChecked) {
+            throw new LikeException.UpdateParameterException(Map.of("followChecked", Boolean.toString(followChecked)));
+        }
+        return createPartyFollow(user, party);
 
-        return partyFollow.isPresent() ? updatePartyFollow(partyFollow.get(), followChecked) : createPartyFollow(user, party, followChecked);
     }
 
 
-    private PartyFollowResponse createPartyFollow(User user, Party party, boolean followChecked) {
-        isEqual(false, followChecked);
+    private PartyFollowResponse createPartyFollow(User user, Party party) {
         var partyFollow = PartyFollow.builder()
                 .party(party)
                 .user(user)
-                .followChecked(followChecked)
                 .build();
         partyFollowRepository.save(partyFollow);
-        return PartyFollowResponse.from(partyFollow);
+        return PartyFollowResponse.from(true);
     }
-
-    private PartyFollowResponse updatePartyFollow(PartyFollow partyFollow, boolean followChecked) {
-        isEqual(partyFollow.isFollowChecked(), followChecked);
-        partyFollow.setFollowChecked(followChecked);
-        partyFollowRepository.save(partyFollow);
-
-        return PartyFollowResponse.from(partyFollow);
+    private PartyFollowResponse deletePartyFollow(PartyFollow partyFollow) {
+        partyFollowRepository.deleteById(partyFollow.getId());
+        return PartyFollowResponse.from(false);
     }
 
 
     private CongressmanLikeResponse createCongressmanLike(User user, Congressman congressman) {
-        var congressmanLike = CongressManLike.builder()
+        var congressmanLike = com.everyones.lawmaking.domain.entity.CongressmanLike.builder()
                 .congressman(congressman)
                 .user(user)
                 .build();
@@ -107,8 +109,9 @@ public class LikeService {
         return CongressmanLikeResponse.from(true);
     }
 
-    private CongressmanLikeResponse deleteCongressmanLike(CongressManLike congressmanLike) {
+    private CongressmanLikeResponse deleteCongressmanLike(CongressmanLike congressmanLike) {
         congressmanLikeRepository.deleteById(congressmanLike.getId());
+        return CongressmanLikeResponse.from(false);
     }
 
     private BillLikeResponse createBillLike(User user, Bill bill) {
@@ -124,13 +127,5 @@ public class LikeService {
         billLikeRepository.deleteById(billLike.getId());
         return BillLikeResponse.from(false);
     }
-
-    private void isEqual(boolean dbValue, boolean parameterValue) {
-        if (dbValue == parameterValue) {
-            throw new LikeException.UpdateParameterException(Map.of(UPDATE_PARAMETER ,Boolean.toString(parameterValue)));
-        }
-    }
-
-
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
@@ -45,13 +45,6 @@ public class PartyService {
                 .toList();
     }
 
-    @Transactional
-    public void updatePartyFollowCount(Party party, boolean followChecked) {
-        var followCount = followChecked ? party.getFollowCount() + 1 : party.getFollowCount() - 1;
-        party.setFollowCount(followCount);
-        partyRepository.save(party);
-    }
-
     // 검색 파티
     public List<SearchResponse> searchParty(String searchWord) {
         var searchPartyList= partyRepository.findBySearchWord(searchWord);

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -9,8 +9,6 @@ spring.jpa.show-sql=true
 
 # ?? ?? ??????
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
-spring.security.user.name=nws717
-spring.security.user.password=altks2012
 
 #spring.resources.static-locations=classpath:/static/,classpath:/public/,classpath:/some/other/directory/
 


### PR DESCRIPTION
1. 내용
법안 스크랩, 정당 팔로우, 의원 팔로우 기능에서 테이블을 업데이트하는 형식에서 delete하는 방식으로 변경

2. 문제 상황
반정규화로 팔로우 개수를 조회하던 로직에서 팔로우 개수를 테이블을 카운트쿼리로 조회하는 방식으로 변경할 소요가 생김
-> 법안마다 카운트쿼리를 일일이 날리는 방식말고 한번에 카운트쿼리를 날리는 방식을 사용하고 싶은데 그것이 고민임.
ex. 페이징을 통해 법안 3개를 도출했을 때, 법안 하나당 카운트쿼리를 날리면 쿼리 개수가 2배가 됨.