### PR TITLE
AI 모델 (chat gpt)의 비용 문제로 keyword컬럼 삭제

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDetailInfo.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDetailInfo.java
@@ -16,12 +16,10 @@ import java.time.LocalDate;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BillDetailInfo extends BillInfoDto{
 
-    private String[] keyword;
     private String billLink;
 
     public BillDetailInfo(Bill bill) {
         super(bill);
-        this.keyword = bill.getKeyword().split(", ");
         this.billLink = bill.getBillLink();
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -68,7 +68,6 @@ public class Bill {
     @Column(name = "gpt_summary", columnDefinition = "TEXT")
     private String gptSummary;
 
-    private String keyword;
 
     @Column(name = "bill_pdf_url")
     private String billPdfUrl; // PDF 파일의 경로 또는 식별자


### PR DESCRIPTION
## 내용
AI 모델 (chat gpt)의 비용 문제로 keyword컬럼 삭제로 인해 엔티티를 수정하고 법안 상세조회 메서드 수정