### PR TITLE
토큰 재발급 오류 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/AuthController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/AuthController.java
@@ -15,10 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
 
@@ -69,7 +66,7 @@ public class AuthController {
                     )}
             ),
     })
-    @PatchMapping("/reissue/token")
+    @PostMapping("/reissue/token")
     public BaseResponse<String> reissueToken(
             HttpServletRequest request,
             HttpServletResponse response) throws Exception {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/CorsConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig implements WebMvcConfigurer {
         var corsConfig = new CorsConfiguration();
         corsConfig.setAllowedHeaders(List.of("*"));
         corsConfig.setAllowedMethods(List.of("*"));
-        corsConfig.setAllowedOrigins(List.of("https://law-digest-fe-git-fork-ijaesin-fix-133-ijaesins-projects.vercel.app/","http://localhost.lawdigest.net:3000","https://localhost.lawdigest.net:3000","https://api.lawdigest.net","http://localhost:3000", "https://localhost:3000","https://lawdigest.store","https://lawdigest.net","https://www.lawdigest.net", "https://lawDigest.net:3000","https://law-digest-fe.vercel.app/","https://law-digest-fe.vercel.app*"));
+        corsConfig.setAllowedOrigins(List.of("http://localhost.lawdigest.net:3000","https://localhost.lawdigest.net:3000","https://api.lawdigest.net","http://localhost:3000", "https://localhost:3000","https://lawdigest.store","https://lawdigest.net","https://www.lawdigest.net", "https://lawDigest.net:3000","https://law-digest-fe.vercel.app/","https://law-digest-fe.vercel.app*"));
         corsConfig.setAllowCredentials(true);
         corsConfig.setMaxAge(3600L);
 


### PR DESCRIPTION
## 내용
preflight 설정에 patch가 없는데 재발급 method를 patch로 설정해서 재발급 요청이 되지 않고 있었음.
그런데 patch로 설정할 이유가 없기 때문에 post method로 변경.

추가로 cors허용 호스트네임에서 이미 완료한 모바일 테스트 호스트네임을 삭제함
