### PR TITLE
Fix/bill scrap/method

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
@@ -146,7 +146,7 @@ public class BillController {
                     )}
             ),
     })
-    @PostMapping("/user/bookmark")
+    @PatchMapping("/user/bookmark")
     public BaseResponse<BillLikeResponse> likeBill(
             Authentication authentication,
             @Parameter(example = "PRC_G2O3O1N2O1M1K1L5A0A8Z2Z2Y7W6X3")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/CorsConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig implements WebMvcConfigurer {
 
         var corsConfig = new CorsConfiguration();
         corsConfig.setAllowedHeaders(List.of("*"));
-        corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        corsConfig.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         corsConfig.setAllowedOrigins(List.of("http://localhost.lawdigest.net:3000","https://localhost.lawdigest.net:3000","https://api.lawdigest.net","http://localhost:3000", "https://localhost:3000","https://lawdigest.store","https://lawdigest.net","https://www.lawdigest.net", "https://lawDigest.net:3000","https://law-digest-fe.vercel.app/","https://law-digest-fe.vercel.app*"));
         corsConfig.setAllowCredentials(true);
         corsConfig.setMaxAge(3600L);


### PR DESCRIPTION
## 내용
법안 스크랩 요청시 post요청이 되면 캐시(의심)과 같은 문제 때문에 법안 상세 페이지에서 스크랩여부가 확인되지 않음.
다른 의원과 정당 follow와 같은 동작방식이기 때문에 patch로 변경해서 문제해결 시도

corsConfig에서 http method 설정을 ArrayList로 했는데 List로 변경해서 리스트 크기 변경의 오버헤드를 줄임.