### PR TITLE
데이터 최신화 업데이트 수정 pull request

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/LawmakerDfRequest.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/LawmakerDfRequest.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LawmakerDfRequest {
 
+    private boolean isInsert;
     private String congressmanId;
     private String congressmanName;
     private String congressmanImageUrl;
@@ -17,5 +18,11 @@ public class LawmakerDfRequest {
     private String elected;
     private String homepage;
     private String district;
+    private String congressmanBirth;
+    private String sex;
+    private String email;
+    private String congressmanOffice;
+    private String congressmanTelephone;
     private int assemblyNumber;
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -94,8 +94,13 @@ public class Bill {
                 .gptSummary(billDfRequest.getGptSummary())
                 .summary(billDfRequest.getSummary())
                 .briefSummary(billDfRequest.getBriefSummary())
-                .billLink("https://likms.assembly.go.kr/bill/billDetail.do?billId="+billDfRequest.getBillId())
                 .build();
+    }
+
+    public void update(BillDfRequest billDfRequest){
+        this.setSummary(billDfRequest.getSummary());
+        this.setGptSummary(billDfRequest.getGptSummary());
+        this.setBriefSummary(billDfRequest.getBriefSummary());
     }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -53,6 +53,25 @@ public class Congressman {
     @Column(name = "homepage")
     private String homepage;
 
+    @Column(name = "state",columnDefinition = "boolean default false")
+    private Boolean state;
+
+    @Column(name = "congressman_age")
+    private String congressmanAge;
+
+    @Column(name = "sex")
+    private String sex;
+
+    @Column(name = "congressma_telephone")
+    private String congressmanTelephone;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "congressman_office")
+    private String congressmanOffice;
+
+
     @ColumnDefault("0")
     @Column(name = "represent_count")
     private int representCount;
@@ -78,7 +97,6 @@ public class Congressman {
 
 
     public static Congressman of(LawmakerDfRequest lawmakerDfRequest,Party party){
-        String electSort = Congressman.getElectSort(lawmakerDfRequest.getDistrict());
         String congressmanId = lawmakerDfRequest.getCongressmanId();
         int assemblyNumber = lawmakerDfRequest.getAssemblyNumber();
         String congressmanImageUrl = "/congressman/" + assemblyNumber + "/" + congressmanId + ".jpg";
@@ -91,14 +109,18 @@ public class Congressman {
                 .elected(lawmakerDfRequest.getElected())
                 .homepage(lawmakerDfRequest.getHomepage())
                 .district(lawmakerDfRequest.getDistrict())
-                .electSort(electSort)
                 .congressmanImageUrl(congressmanImageUrl)
+                .congressmanAge(lawmakerDfRequest.getCongressmanBirth())
+                .congressmanOffice(lawmakerDfRequest.getCongressmanOffice())
+                .congressmanTelephone(lawmakerDfRequest.getCongressmanTelephone())
+                .sex(lawmakerDfRequest.getSex())
+                .email(lawmakerDfRequest.getEmail())
+                .state(true)
                 .build();
 
     }
 
-    public Congressman update(LawmakerDfRequest lawmakerDfRequest,Party party){
-        String electSort = Congressman.getElectSort(lawmakerDfRequest.getDistrict());
+    public void update(LawmakerDfRequest lawmakerDfRequest,Party party){
         this.setId(lawmakerDfRequest.getCongressmanId());
         this.setName(lawmakerDfRequest.getCongressmanName());
         this.setParty(party);
@@ -107,14 +129,22 @@ public class Congressman {
         this.setElected(lawmakerDfRequest.getElected());
         this.setHomepage(lawmakerDfRequest.getHomepage());
         this.setDistrict(lawmakerDfRequest.getDistrict());
-        this.setElectSort(electSort);
-        return this;
+        this.setCongressmanAge(lawmakerDfRequest.getCongressmanBirth());
+        this.setCongressmanOffice(lawmakerDfRequest.getCongressmanOffice());
+        this.setCongressmanTelephone(lawmakerDfRequest.getCongressmanTelephone());
+        this.setSex(lawmakerDfRequest.getSex());
+        this.setEmail(lawmakerDfRequest.getEmail());
 
     }
 
-    private static String getElectSort(String district) {
-        return district.equals("비례대표") ? "비례대표" : "지역구";
+    public void updateState(Boolean changedState){
+        this.setState(changedState);
+        if(!changedState){
+            this.setElectSort("");
+            this.setDistrict("");
+        }
     }
+
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -80,11 +80,22 @@ public class Party extends BaseEntity{
                 .build();
     }
 
-    public void update(String district){
-        int districtCongressmanCount = district.equals("비례대표") ? 0 : 1;
-        int proportionalCongressmanCount = district.equals("비례대표") ? 1 : 0;
-        this.setDistrictCongressmanCount(this.districtCongressmanCount+districtCongressmanCount);
-        this.setProportionalCongressmanCount(this.proportionalCongressmanCount+proportionalCongressmanCount);
+    public void addCongressmanCount(String district){
+        if (district.equals("비례대표")){
+            this.setDistrictCongressmanCount(this.districtCongressmanCount+1);
+        }
+        else{
+            this.setProportionalCongressmanCount(this.proportionalCongressmanCount+1);
+        }
+    }
+
+    public void subCongressmanCount(String district){
+        if (district.equals("비례대표")){
+            this.setDistrictCongressmanCount(this.districtCongressmanCount-1);
+        }
+        else{
+            this.setProportionalCongressmanCount(this.proportionalCongressmanCount-1);
+        }
     }
 
     @Override
@@ -93,6 +104,7 @@ public class Party extends BaseEntity{
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", districtCongressmanCount=" + districtCongressmanCount +
+                ", proportionalCongressmanCount=" + proportionalCongressmanCount +
                 '}';
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/QueryLoggingConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/QueryLoggingConfig.java
@@ -20,7 +20,7 @@ public class QueryLoggingConfig {
     }
 
 
-    @After("execution(* com.everyones.lawmaking.service.*.*(..))")
+    @After("execution(* com.everyones.lawmaking.service..*(..)) && !execution(* com.everyones.lawmaking.service.dataservice..*(..))")
     public void enableQueryLoggingConfig() {
         hibernateSqlLogger.setLevel(Level.DEBUG);
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface CongressmanRepository extends JpaRepository<Congressman, String> {
@@ -33,10 +34,14 @@ public interface CongressmanRepository extends JpaRepository<Congressman, String
             "ORDER BY c.name ")
     Slice<Congressman> findByPage(@Param("partyId") long partyId, Pageable pageable);
 
-
-    Optional<Congressman> findCongressmanByNameAndAssemblyNumber(String congressmanName, int assemblyNumber);
+    @Query("SELECT c FROM Congressman c " +
+            "Where c.state = true and c.name =:congressmanName ")
+    Optional<Congressman> findLawmakerByName(String congressmanName);
 
 
     Optional<Congressman> findCongressmanById(String congressmanId);
+
+    @Query("SELECT c.id FROM Congressman c ")
+    Set<String> findAllCongressmanId();
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -9,16 +9,14 @@ import com.everyones.lawmaking.global.error.BillException;
 import com.everyones.lawmaking.global.error.CongressmanException;
 import com.everyones.lawmaking.global.error.PartyException;
 import com.everyones.lawmaking.repository.*;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -37,38 +35,50 @@ public class DataService {
         // stream으로 dto 각각을 맞는 부분에 넣어야함.
         // 중간에 로직이 필요하면 로직을 거쳐서 들어가자.
         // 시점 파티 데이터 넣기
-        Integer assemblyNumber = billDfRequestList.get(0).getAssemblyNumber();
-        log.debug(billDfRequestList.toString());
         billDfRequestList
             .forEach(billDfRequest -> {
-
-                //partyName으로 partyId조회해서 리스트 반환하기
-                List<Long> partyIdList = new ArrayList<>();
-                List<String> partyNameList = billDfRequest.getRstProposerPartyNameList();
-                for (String name : partyNameList) {
-                    Party party = partyRepository.findPartyByName(name)
-                            .orElseThrow(() -> new PartyException.PartyNotFound(Map.of("party", name)));
-                    partyIdList.add(party.getId());
+                var oldBill = billRepository.findBillInfoById(billDfRequest.getBillId())
+                        .orElse(null);
+                if (oldBill != null){
+                    oldBill.update(billDfRequest);
                 }
+                else {
+
+                    //partyName으로 partyId조회해서 리스트 반환하기
+                    List<Long> partyIdList = new ArrayList<>();
+                    List<String> partyNameList = billDfRequest.getRstProposerPartyNameList();
+                    for (String name : partyNameList) {
+                        Party party = partyRepository.findPartyByName(name)
+                                .orElseThrow(() -> new PartyException.PartyNotFound(Map.of("party", name)));
+                        partyIdList.add(party.getId());
+                    }
+
                     // 미완성 Bill 객체 생성하여 다른 필요한 자식들에게 넣어주기.
-                    Bill newBill = Bill.of(billDfRequest,partyIdList);
+                    Bill newBill = Bill.of(billDfRequest, partyIdList);
+
                     billRepository.save(newBill);
 
 
-
-                //이름으로 congressmanId를 찾아서 billProposer 저장하기
-                billDfRequest.getPublicProposers()
-                        .forEach(congressmanName -> {
-                            billProposerUpdate(newBill, assemblyNumber, congressmanName);
-                                }
-                        );
+                    //이름으로 congressmanId를 찾아서 billProposer 저장하기
+                    //@ToDo 동명이인 필터링을 위해 후에 의원검색에 한글이름, 한자이름, 정당이름 세가지 조건을 추가하기.
+                    //현재는 state가 true인 조건만 추가
+                    //트랜잭션에서 에러가 발생하면 모든 트랜잭션이 롤백해야함.
+                    billDfRequest.getPublicProposers()
+                            .forEach(congressmanName -> {
+                                var billProposer = congressmanRepository.findLawmakerByName(congressmanName)
+                                        .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", congressmanName)));
+                                        billProposerUpdate(newBill, billProposer);
+                                    }
+                            );
                     //대표발의자 이름 검색해서 RP 찾기
                     var representativeProposerName = billDfRequest.getRstProposerNameList();
-                representativeProposerName.forEach((rpName) -> {
-                    updateRepresentativeProposer(newBill, rpName, assemblyNumber);
-                        }
-                );
-
+                    representativeProposerName.forEach((rpName) -> {
+                        var representativeProposer = congressmanRepository.findLawmakerByName(rpName)
+                                .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", rpName)));
+                        updateRepresentativeProposer(newBill, representativeProposer);
+                            }
+                    );
+                }
                 }
             );
 
@@ -105,97 +115,214 @@ public class DataService {
         );
     }
 
+    @Transactional
     public void updateLawmakerDf(List<LawmakerDfRequest> lawmakerDfRequestList) {
 
-        lawmakerDfRequestList.forEach(
-                // bill number로 bill을 찾고 내용 수정하자!
-                this::updateLawmaker
-        );
+        // 삽입 :국회 API 호출 데이터 - (API 교집합 DB의원데이터)
+        // state false로 만들기 진행: 디비 의원 데이터 - (API 교집합 DB의원데이터) -> 전부 False로 처리
+        // 교집합 처리: API 교집합 DB의원 데이터를 새롭게 업데이트 해주면서 state True로 처리
+
+        // API 데이터 들을 맵으로 만들기
+        Map<String,LawmakerDfRequest> lawmakerApiData = new HashMap<>();
+        lawmakerDfRequestList.forEach(lawmaker-> {
+            lawmakerApiData.put(lawmaker.getCongressmanId(), lawmaker);
+        });
+
+        //DB 의원데이터 가져오기
+        Set<String> congressmanSet = new HashSet<>(congressmanRepository.findAllCongressmanId());
+        Set<String> intersectionWithApiAndDB = new HashSet<>(congressmanSet);
+
+        //API 데이터 집합
+        Set<String> lawmakerApi = new HashSet<>(lawmakerApiData.keySet());
+
+        //디비에 존재하는 현재 의원 데이터
+        intersectionWithApiAndDB.retainAll(lawmakerApi);
+
+        //삽입해야하는 차집합
+        lawmakerApi.removeAll(intersectionWithApiAndDB);
+        congressmanSet.removeAll(intersectionWithApiAndDB);
+
+        //삽입 과정 진행
+        lawmakerApi.forEach((insertLawmaker)->
+                this.insertLawmaker(lawmakerApiData.get(insertLawmaker)));
+
+        //상태 false로 만들기 진행
+        congressmanSet.forEach(
+
+                (updateStateFalseCongressman)-> {
+                    var congressmanUpdateToFalse = congressmanRepository.findCongressmanById(updateStateFalseCongressman)
+                            .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", updateStateFalseCongressman)));
+                    lawmakerStateToFalse(congressmanUpdateToFalse);
+                });
+
+        //수정 과정 진행
+        //API로 들어온 의원리스트로 기존 의원 데이터 최신화 시키기
+        intersectionWithApiAndDB.forEach((updateStateTrueCongressmanId)->{
+            var congressmanUpdateToTrue = congressmanRepository.findCongressmanById(updateStateTrueCongressmanId)
+                    .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", updateStateTrueCongressmanId)));
+            lawmakerStateToTrue(lawmakerApiData.get(updateStateTrueCongressmanId),congressmanUpdateToTrue);
+        });
+
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void billProposerUpdate(Bill newBill, Integer assemblyNumber, String congressmanName){
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void billProposerUpdate(Bill newBill, Congressman billProposer){
         boolean publicProposersUpdated = false;
         while (!publicProposersUpdated) {
             try{
-
-                var congressman = congressmanRepository.findCongressmanByNameAndAssemblyNumber(congressmanName,assemblyNumber)
-                        .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", congressmanName)));
                 var newBillProposer = BillProposer.builder()
                         .bill(newBill)
-                        .congressman(congressman)
+                        .congressman(billProposer)
                         .build();
+
                 billProposerRepository.save(newBillProposer);
-                congressman.setPublicCount(congressman.getPublicCount() + 1);
+
+                billProposer.setPublicCount(billProposer.getPublicCount() + 1);
+                congressmanRepository.save(billProposer);
+
                 publicProposersUpdated = true;
+
             }
             //트랜잭션관리를 위해서 예외처리
-            catch(OptimisticLockException e){
+            catch(ObjectOptimisticLockingFailureException e){
                 log.warn("pP update lock conflict", e);
-
             }
 
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateRepresentativeProposer(Bill newBill, String rpName,Integer assemblyNumber){
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void updateRepresentativeProposer(Bill newBill, Congressman representativeProposer){
         boolean representativeUpdated = false;
         while (!representativeUpdated) {
             try {
-                var congressmanForRep = congressmanRepository.findCongressmanByNameAndAssemblyNumber(rpName,assemblyNumber)
-                        .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", rpName)));
 
                 var repProposer = RepresentativeProposer.builder()
                         .bill(newBill)
-                        .congressman(congressmanForRep)
+                        .congressman(representativeProposer)
                         .build();
-                congressmanForRep.setRepresentCount(congressmanForRep.getRepresentCount() + 1);
+
+                representativeProposer.setRepresentCount(representativeProposer.getRepresentCount() + 1);
+
+
                 //RP 저장
+
                 representativeProposerRepository.save(repProposer);
+                congressmanRepository.save(representativeProposer);
                 representativeUpdated = true;
             }
 
+
             //트랜잭션관리를 위해서 예외처리
-            catch(OptimisticLockException e){
+            catch(ObjectOptimisticLockingFailureException e){
                 log.warn("rp update lock conflict", e);
+
 
             }
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateLawmaker(LawmakerDfRequest ldr){
-        boolean updated = false;
-        while (!updated) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void insertLawmaker(LawmakerDfRequest ldr) {
+        boolean partyUpdated = false;
+        while (!partyUpdated) {
             try {
-                var congressman = congressmanRepository.findCongressmanById(ldr.getCongressmanId()).orElse(null);
                 String partyName = ldr.getPartyName();
                 var party = partyRepository.findPartyByName(partyName).orElse(null);
 
                 if (party == null) {
                     party = Party.create(partyName, ldr.getDistrict());
+                } else {
+                    // 정당 정보 업데이트
+                    party.addCongressmanCount(ldr.getDistrict());
                 }
 
-                if (congressman != null) {
-                    congressman.update(ldr, party);
-                } else {
-                    congressman = Congressman.of(ldr, party);
-                    party.update(ldr.getDistrict());
-                }
+                var congressman = Congressman.of(ldr, party);
+
+                //party는 flush가 되는게 좋으므로 가독성을 위해 flush처리
+                partyRepository.saveAndFlush(party);
+                congressmanRepository.save(congressman);
+                partyUpdated = true;
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.warn("party update lock conflict", e);
+
+            }
+        }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void lawmakerStateToFalse(Congressman lawmaker) {
+        boolean partyUpdated = false;
+        boolean congressmanUpdate = false;
+        while (!partyUpdated & !congressmanUpdate) {
+            try {
+                String partyName = lawmaker.getParty().getName();
+                var party = partyRepository.findPartyByName(partyName).orElseThrow(
+                        ()-> new PartyException.PartyNotFound(Map.of("party",partyName))
+                );
 
                 // 정당 정보 업데이트
+                party.subCongressmanCount(lawmaker.getDistrict());
+                lawmaker.updateState(false);
 
-                // 트랜잭션 커밋 시점에 Optimistic Lock 검증
-                partyRepository.save(party);
-                congressmanRepository.save(congressman);
+                //party는 flush가 되는게 좋으므로 가독성을 위해 flush처리
+                partyRepository.saveAndFlush(party);
+                congressmanRepository.save(lawmaker);
+                partyUpdated = true;
+                congressmanUpdate = true;
 
-                updated = true;
-            //트랜잭션관리를 위해서 예외처리
-            } catch (OptimisticLockException e) {
-                log.warn("Optimistic lock conflict", e);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.warn("party update lock conflict", e);
+
+            }
+        }
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void lawmakerStateToTrue(LawmakerDfRequest ldr,Congressman congressmanStateUpdateTrue) {
+        boolean partyUpdated = false;
+        boolean congressmanUpdate = false;
+        while (!partyUpdated & !congressmanUpdate) {
+            try {
+                //과거 정당에서 의원유형별 의원수 변경
+                //의원 정보만 업데이트 할 수도 있음
+                String partyName = congressmanStateUpdateTrue.getParty().getName();
+                var party = partyRepository.findPartyByName(partyName).orElseThrow(
+                        ()-> new PartyException.PartyNotFound(Map.of("party",partyName))
+                );
+                // 정당 정보 업데이트
+                party.subCongressmanCount(congressmanStateUpdateTrue.getDistrict());
+                if (partyName.equals(ldr.getPartyName())){
+                    party.addCongressmanCount(ldr.getDistrict());
+                    congressmanStateUpdateTrue.update(ldr, party);
+                }
+                else{
+                    //달라진 정당에 의원 수 수정
+                    var newParty = partyRepository.findPartyByName(ldr.getPartyName()).orElseThrow(
+                            ()-> new PartyException.PartyNotFound(Map.of("party",partyName))
+                    );
+                    newParty.addCongressmanCount(ldr.getDistrict());
+                    congressmanStateUpdateTrue.update(ldr, newParty);
+                    partyRepository.saveAndFlush(newParty);
+
+                }
+
+                //의원 상태 변경
+                congressmanStateUpdateTrue.updateState(true);
+
+                //flush처리 되지만 가독성을 위해 flush처리
+                partyRepository.saveAndFlush(party);
+                congressmanRepository.save(congressmanStateUpdateTrue);
+                partyUpdated = true;
+                congressmanUpdate = true;
+
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.warn("party update lock conflict", e);
+
             }
         }
     }
 
 }
+
+


### PR DESCRIPTION
## 내용
1. 의원 상태관리의 필요성으로 state컬럼을 추가해서 congressmanID로 집합연산하여
데이터 베이스에서 비활성화 해야하는 의원, 활성화 해야하는 의원, API에서 불러온 의원 추가
2. 법안 삽입시, 이미 있는 법안 같은 경우 gptSummary, BriefSummary, Summary 수정
3. 쿼리 로그 수정 -> 데이터 최신화관련 로그는 로깅 비활성화
4. 정당의 비례대표 지역구대표 카운팅 함수 수정