### PR TITLE
배포 로그 설정 변경

### DIFF
--- a/lawmaking/src/main/resources/logback-spring.xml
+++ b/lawmaking/src/main/resources/logback-spring.xml
@@ -24,8 +24,8 @@
         <property name="FILE_NAME" value="/var/logs/spring.log" />
         <property name="LOG_NAME_PATTERN" value="/var/logs/spring-%d{yyyy-MM-dd-HH-mm}.%i.log" />
         <property name="MAX_FILE_SIZE" value="100MB" />
-        <property name="TOTAL_SIZE" value="300MB" />
-        <property name="MAX_HISTORY" value="2" />
+        <property name="TOTAL_SIZE" value="2000MB" />
+        <property name="MAX_HISTORY" value="20" />
 
         <!-- Console appender 설정 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
## 내용
한 로그파일을 100mb제한
모든 로그파일들의 합 2기가로 제한
모든 로그 파일 개수를 20개로 제한