### PR TITLE
일 단위로 로그파일 설정

### DIFF
--- a/lawmaking/src/main/resources/logback-spring.xml
+++ b/lawmaking/src/main/resources/logback-spring.xml
@@ -22,10 +22,9 @@
         <property name="CONSOLE_PATTERN" value="%d{yy-MM-dd HH:mm:ss} %highlight(%-5level) [%thread] [%logger{0}-%M:%line] - %msg%n" />
         <property name="ROLLING_PATTERN" value="%d{yy-MM-dd HH:mm:ss.SSS} %-5level %logger{0} - %msg %n" />
         <property name="FILE_NAME" value="/var/logs/spring.log" />
-        <property name="LOG_NAME_PATTERN" value="/var/logs/spring-%d{yyyy-MM-dd-HH-mm}.%i.log" />
-        <property name="MAX_FILE_SIZE" value="100MB" />
-        <property name="TOTAL_SIZE" value="2000MB" />
-        <property name="MAX_HISTORY" value="20" />
+        <property name="LOG_NAME_PATTERN" value="/var/logs/spring-%d{yyyy-MM-dd}.%i.log" />
+        <property name="TOTAL_SIZE" value="3000MB" />
+        <property name="MAX_HISTORY" value="7" />
 
         <!-- Console appender 설정 -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -39,7 +38,6 @@
             <file>${FILE_NAME}</file>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                 <fileNamePattern>${LOG_NAME_PATTERN}</fileNamePattern>
-                <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
                 <totalSizeCap>${TOTAL_SIZE}</totalSizeCap>
                 <maxHistory>${MAX_HISTORY}</maxHistory>
             </rollingPolicy>


### PR DESCRIPTION
## 내용
로그파일 기록들이 계속 사라지는 문제를 겪음
분단위로 되어있던 설정이 문제가 된다고 생각했고 일단위로 하면 문제가 해결될것이라 생각.
그리고 maxHistory를 7로 조정하고 전체 로그 디렉토리 사이즈를 3기가로 조정