### PR TITLE
party/congressman 에서 paging 제거

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyCongressmanResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyCongressmanResponse.java
@@ -18,13 +18,10 @@ public class PartyCongressmanResponse {
 
     @NotNull
     private List<PartyCongressmanDto> partyCongressman;
-    @NotNull
-    private PaginationResponse paginationResponse;
 
-    public static PartyCongressmanResponse of(List<PartyCongressmanDto> partyCongressmanList, PaginationResponse paginationResponse) {
+    public static PartyCongressmanResponse of(List<PartyCongressmanDto> partyCongressmanList) {
         return PartyCongressmanResponse.builder()
                 .partyCongressman(partyCongressmanList)
-                .paginationResponse(paginationResponse)
                 .build();
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
@@ -93,12 +93,8 @@ public class PartyController {
     })
     @GetMapping("/congressman")
     public BaseResponse<PartyCongressmanResponse> getPartyCongressman(@Parameter(example = "1", description = "정당 id")
-                                                                      @RequestParam("party_id") long partyId,
-                                                                      @Parameter(example = "0", description = "스크롤할 때마다 page값을 0에서 1씩 늘려주면 됩니다.")
-                                                                      @RequestParam(name = "page") int page) {
-        var pageable = PageRequest.of(page, 16);
-        var result = facade.getPartyCongressman(partyId, pageable);
-
+                                                                      @RequestParam("party_id") long partyId){
+        var result = facade.getPartyCongressman(partyId);
         return BaseResponse.ok(result);
 
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -122,8 +122,8 @@ public class Facade {
         return setBillListResponseBookMark(billListResponse);
     }
 
-    public PartyCongressmanResponse getPartyCongressman(long partyId, Pageable pageable) {
-        return congressmanService.getPartyCongressman(partyId, pageable);
+    public PartyCongressmanResponse getPartyCongressman(long partyId) {
+        return congressmanService.getPartyCongressman(partyId);
     }
 
     // 법안 좋아요 기능

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
@@ -32,7 +32,7 @@ public interface CongressmanRepository extends JpaRepository<Congressman, String
     @Query("SELECT c FROM Congressman c " +
             "JOIN c.party p WHERE p.id = :partyId " +
             "ORDER BY c.name ")
-    Slice<Congressman> findByPage(@Param("partyId") long partyId, Pageable pageable);
+    Slice<Congressman> findByPage(@Param("partyId") long partyId);
 
     @Query("SELECT c FROM Congressman c " +
             "Where c.state = true and c.name =:congressmanName ")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/CongressmanService.java
@@ -35,13 +35,12 @@ public class CongressmanService {
         return congressman;
     }
 
-    public PartyCongressmanResponse getPartyCongressman(long partyId, Pageable pageable) {
-        var congressman = congressmanRepository.findByPage(partyId, pageable);
-        var pagination = PaginationResponse.from(congressman);
+    public PartyCongressmanResponse getPartyCongressman(long partyId) {
+        var congressman = congressmanRepository.findByPage(partyId);
         var congresssmanList = congressman.stream()
                 .map(PartyCongressmanDto::from)
                 .toList();
-        return PartyCongressmanResponse.of(congresssmanList, pagination);
+        return PartyCongressmanResponse.of(congresssmanList);
     }
 
     public List<LikingCongressmanResponse> getLikingCongressman(long userId){


### PR DESCRIPTION
## 내용
정당별 의원 목록을 가져오는 api를 사용하는 부분을 아코디언 UI로 변경하는 과정에서
페이징 기법 삭제가 필요하여 작업.