### PR TITLE
비례대표, 지역구 의원 카운트 업데이트 api

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
@@ -181,5 +181,27 @@ public class DataController {
 
     }
 
+    @Operation(summary = "의원 카운트 업데이트 API", description = "정당별 비례대표, 지역구 의원 카운트 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PostMapping("/congressman/party/count")
+    public BaseResponse<String> updateCongressmanCountByParty() {
+        // 존재하지 않는 법안 ID 리스트
+        facade.updateCongressmanCountByParty();
+        return BaseResponse.ok("200");
+    }
+
+
+
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
@@ -103,7 +103,7 @@ public class DataController {
             @RequestBody BillResultListDfRequest billResultListDfRequest) {
         var billDfRequestList=billResultListDfRequest.getBillResultDfRequestList();
         facade.updateBillResultDf(billDfRequestList);
-        return BaseResponse.ok("200");
+        return BaseResponse.ok("당일 법안 본회의 처리 결과 수집 수정 데이터 요청 성공");
 
     }
 
@@ -127,7 +127,7 @@ public class DataController {
         var lawmakerDfRequestList=lawmakerListDfRequest.getLawmakerDfRequestList();
 
         facade.updateLawmakerDf(lawmakerDfRequestList);
-        return BaseResponse.ok("200");
+        return BaseResponse.ok("국회의원 정보 수집 삽입 데이터 요청 성공");
 
     }
 
@@ -198,7 +198,7 @@ public class DataController {
     public BaseResponse<String> updateCongressmanCountByParty() {
         // 존재하지 않는 법안 ID 리스트
         facade.updateCongressmanCountByParty();
-        return BaseResponse.ok("200");
+        return BaseResponse.ok("국회의원 정보 수집 삽입 데이터 요청 성공");
     }
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -75,6 +75,11 @@ public class Party extends BaseEntity{
                 .build();
     }
 
+    public void updateCongressmanCount(int districtCongressmanCount, int proportionalCongressmanCount){
+        this.setDistrictCongressmanCount(districtCongressmanCount);
+        this.setProportionalCongressmanCount(proportionalCongressmanCount);
+    }
+
 
 
     @Override

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -319,6 +319,10 @@ public class Facade {
 
     }
 
+    public void updateCongressmanCountByParty(){
+        dataService.updateCongressmanCountByParty();
+    }
+
 
 
     public List<BillDto> getPopularBills() {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/QuerydslConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/QuerydslConfig.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.global.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +10,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class QuerydslConfig {
-    private final EntityManager entityManager;
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepositoryCustom.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepositoryCustom.java
@@ -1,0 +1,30 @@
+package com.everyones.lawmaking.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.everyones.lawmaking.domain.entity.QCongressman.congressman;
+
+@Repository
+@RequiredArgsConstructor
+public class CongressmanRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public Integer countCongressmanByPartyId(Long partyId, boolean isProportional) {
+        Long congressmanCount = queryFactory.select(congressman.count())
+                .from(congressman)
+                .where(
+                        congressman.state.isTrue()
+                                .and(congressman.party.id.eq(partyId))
+                                .and(isProportional ?
+                                        congressman.district.eq("비례대표") :
+                                        congressman.district.ne("비례대표"))
+                )
+                .fetchOne();
+
+        return congressmanCount != null ? congressmanCount.intValue() : 0;
+    }
+
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -27,6 +27,7 @@ public class DataService {
     private final BillTimelineRepository billTimelineRepository;
     private final VoteRecordRepository voteRecordRepository;
     private final VotePartyRepository votePartyRepository;
+    private final CongressmanRepositoryCustom congressmanRepositoryCustom;
 
     @Transactional
     public void insertBillInfoDf(List<BillDfRequest> billDfRequestList) {
@@ -340,6 +341,19 @@ public class DataService {
         //flush처리 되지만 가독성을 위해 flush처리
         congressmanRepository.save(congressmanStateUpdateTrue);
     }
+
+    @Transactional
+    public void updateCongressmanCountByParty() {
+        List<Party> partyList = partyRepository.findAll();
+        partyList.forEach(party -> {
+            var proportionalCongressmanCount = congressmanRepositoryCustom.countCongressmanByPartyId(party.getId(), true);
+            var districtCongressmanCount = congressmanRepositoryCustom.countCongressmanByPartyId(party.getId(),false);
+            party.updateCongressmanCount(districtCongressmanCount, proportionalCongressmanCount);
+            partyRepository.save(party);
+        });
+    }
+
+
 }
 
 


### PR DESCRIPTION
## 내용
비례대표, 지역구 의원 카운트 업데이트 api

## 상세내용
조건에 따라 카운트하는 대상이 달라지므로(비례대표, 지역구의원)
동적쿼리를 사용해야했기때문에 queryDSL을 사용하여 해당 기능 작성