### PR TITLE
정당별 대표발의, 공동발의 법안 카운트 데이터 업데이트 api

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/DataController.java
@@ -201,6 +201,26 @@ public class DataController {
         return BaseResponse.ok("국회의원 정보 수집 삽입 데이터 요청 성공");
     }
 
+    @Operation(summary = "정당별 법안 카운트 업데이트 API", description = "정당별 법안 카운트 업데이트 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PostMapping("/bill/party/count")
+    public BaseResponse<String> updateBillCountByParty() {
+        // 존재하지 않는 법안 ID 리스트
+        facade.updateBillCountByParty();
+        return BaseResponse.ok("정당별 법안 카운트 업데이트 수정 데이터 요청 성공");
+    }
+
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -80,6 +80,11 @@ public class Party extends BaseEntity{
         this.setProportionalCongressmanCount(proportionalCongressmanCount);
     }
 
+    public void updateBillCount(int representativeBillCount, int publicBillCount){
+        this.setRepresentativeBillCount(representativeBillCount);
+        this.setPublicBillCount(publicBillCount);
+    }
+
 
 
     @Override

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -322,6 +322,10 @@ public class Facade {
     public void updateCongressmanCountByParty(){
         dataService.updateCongressmanCountByParty();
     }
+    public void updateBillCountByParty(){
+        dataService.updateBillCountByParty();
+    }
+
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepositoryCustom.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepositoryCustom.java
@@ -1,0 +1,48 @@
+package com.everyones.lawmaking.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.everyones.lawmaking.domain.entity.QBill.bill;
+import static com.everyones.lawmaking.domain.entity.QBillProposer.billProposer;
+import static com.everyones.lawmaking.domain.entity.QRepresentativeProposer.representativeProposer;
+
+@Repository
+@RequiredArgsConstructor
+public class PartyRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Integer countBillCountByPartyId(Long partyId, boolean isRepresentativeProposer) {
+        JPQLQuery<Integer> subQuery;
+
+        if (isRepresentativeProposer) {
+            subQuery = JPAExpressions
+                    .selectOne()
+                    .from(representativeProposer)
+                    .where(representativeProposer.bill.eq(bill)
+                            .and(representativeProposer.congressman.party.id.eq(partyId)));
+        } else {
+            subQuery = JPAExpressions
+                    .selectOne()
+                    .from(billProposer)
+                    .where(billProposer.bill.eq(bill)
+                            .and(billProposer.congressman.party.id.eq(partyId)));
+
+        }
+
+        // 메인 쿼리
+        Long count = jpaQueryFactory
+                .select(bill.count())
+                .from(bill)
+                .where(subQuery.exists())
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+
+    }
+}
+

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -28,6 +28,7 @@ public class DataService {
     private final VoteRecordRepository voteRecordRepository;
     private final VotePartyRepository votePartyRepository;
     private final CongressmanRepositoryCustom congressmanRepositoryCustom;
+    private final PartyRepositoryCustom partyRepositoryCustom;
 
     @Transactional
     public void insertBillInfoDf(List<BillDfRequest> billDfRequestList) {
@@ -349,6 +350,17 @@ public class DataService {
             var proportionalCongressmanCount = congressmanRepositoryCustom.countCongressmanByPartyId(party.getId(), true);
             var districtCongressmanCount = congressmanRepositoryCustom.countCongressmanByPartyId(party.getId(),false);
             party.updateCongressmanCount(districtCongressmanCount, proportionalCongressmanCount);
+            partyRepository.save(party);
+        });
+    }
+
+    @Transactional
+    public void updateBillCountByParty() {
+        List<Party> partyList = partyRepository.findAll();
+        partyList.forEach(party -> {
+            var representativeBillCount = partyRepositoryCustom.countBillCountByPartyId(party.getId(), true);
+            var publicBillCount = partyRepositoryCustom.countBillCountByPartyId(party.getId(),false);
+            party.updateBillCount(representativeBillCount, publicBillCount);
             partyRepository.save(party);
         });
     }


### PR DESCRIPTION
## 내용
쿼리dsl 사용해서
대표발의, 공동발의 의원중에 특정 정당 의원이 있으면 카운트 스캔대상으로 함.