### PR TITLE
party total_bill_count 컬럼 삭제

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -56,11 +56,6 @@ public class Party extends BaseEntity{
 
     @ColumnDefault("0")
     @Builder.Default
-    @Column(name = "total_bill_count")
-    private int totalBillCount = 0;
-
-    @ColumnDefault("0")
-    @Builder.Default
     @Column(name = "representative_bill_count")
     private int representativeBillCount = 0;
 


### PR DESCRIPTION
## 내용
데이터베이스에서 total_bill_count 삭제한 후 party 엔티티에 남아있는 컬럼으로 인해 party 엔티티를 조회하는 시점에서
데이터베이스에서 존재하지않는 해당 컬럼을 포함한 쿼리문을 형성하는데 오류가 생겨서 수정
![image](https://github.com/user-attachments/assets/fd1c4c21-7c19-4526-84db-6e551ec32846)
