### PR TITLE
엑세스토큰 30분으로 수정

### DIFF
--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -23,7 +23,7 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=500
 
 # app jwt token configurations
 app.auth.token-secret= ${TOKEN_SECRET}
-app.auth.access-token-expiry= 2
+app.auth.access-token-expiry= 30
 app.auth.refresh-token-expiry= 10080
 
 # binlog configurations


### PR DESCRIPTION
## 내용
엑세스토큰 이슈해결로 인해 30분으로 수정
엑세스토큰 이슈 예상된 원인

'/reissue/token' api 호출 실패 시, accessToken을 가져오는 코드를 삭제

<삭제된 코드>
const { response } = error;
const newConfig = _.cloneDeep(response!.config);
const accessToken = getCookie(ACCESS_TOKEN)!;
newConfig.headers.Authorization = `Bearer ${accessToken}`;
const result = await axios(newConfig);

return result;

