### PR TITLE
proposerKind 컬럼 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/BillDfRequest.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/BillDfRequest.java
@@ -41,5 +41,7 @@ public class BillDfRequest {
 
     private List<String> rstProposerPartyNameList;
 
+    private String proposerKind;
+
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -71,6 +71,11 @@ import java.util.List;
     @Column(name = "bill_result")
     private String billResult;
 
+    @Column(name = "proposer_kind")
+    @ColumnDefault("'CONGRESSMAN'")
+    @Enumerated(EnumType.STRING)
+    private ProposerKindType proposerKind;
+
     @Column(columnDefinition = "TEXT")
     private String summary;
 
@@ -106,6 +111,7 @@ import java.util.List;
                 .gptSummary(billDfRequest.getGptSummary())
                 .summary(billDfRequest.getSummary())
                 .briefSummary(billDfRequest.getBriefSummary())
+                .proposerKind(ProposerKindType.from(billDfRequest.getProposerKind()))
                 .build();
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ProposerKindType.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ProposerKindType.java
@@ -1,0 +1,30 @@
+package com.everyones.lawmaking.domain.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ProposerKindType {
+
+    CONGRESSMAN("의원"),
+    CHAIRMAN("위원장");
+
+    private final String proposerKind;
+
+    public static ProposerKindType from(String stringValue) {
+        if (stringValue == null) {
+            throw new IllegalArgumentException("Proposer kind type cannot be null.");
+        }
+
+        for (ProposerKindType proposerKindType : ProposerKindType.values()) {
+            if (proposerKindType.getProposerKind().equals(stringValue)) {
+                return proposerKindType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown proposer kind type: " + stringValue);
+
+    }
+
+
+}


### PR DESCRIPTION
## 내용
위원회 발의안인지 의원 발의안인지에 따라 알림에 따라 알림에 이미지를 넣는 방법이 다르기 때문에
발의자의 종류를 구분해주는 컬럼이 필요하게 되어, 컬럼을 추가함