### PR TITLE
알림 기능 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -27,6 +27,8 @@ public class NotificationResponse {
     @NotNull
     private String target;
 
+    private String extra;
+
     @NotNull
     private List<String> notificationImageUrlList;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/ColumnEventType.java
@@ -20,13 +20,20 @@ public enum ColumnEventType {
             "Bill",
             "stage",
             EventType.UPDATE,
-            List.of("bill_id", "bill_name", "proposers", "stage")),
+            List.of("bill_id")),
+
+    BILL_RESULT_UPDATE(
+            "bill_result_update",
+            "Bill",
+            "bill_result",
+            EventType.UPDATE,
+            List.of("bill_id")),
     CONGRESSMAN_PARTY_UPDATE(
             "congressman_party_update",
             "Congressman",
             "party_id",
             EventType.UPDATE,
-            List.of("congressman_id", "party_id", "name"));
+            List.of("congressman_id"));
 
     public enum EventType {
         INSERT, UPDATE, DELETE
@@ -35,7 +42,7 @@ public enum ColumnEventType {
     private final String tableName;
     private final String columnName;
     private final EventType eventType;
-    private final List<String> resultColumnNames;
+    private final List<String> keyColumns;
 
     public static ColumnEventType from(String code) {
         return Arrays.stream(ColumnEventType.values())

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/NotificationCreator.java
@@ -24,15 +24,20 @@ public class NotificationCreator {
     private final Facade facade;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    //ToDo: 알림 데이터 삽입 시 유니크키 컬럼을 추가해서 다중 스프링서버환경에서도 중복 데이터가 삽입되지 않도록 처리
     @Transactional
     public void createNotification(List<Map<String, List<String>>> filteredValuesByRows) {
         List<Notification> notifications = new ArrayList<>();
         filteredValuesByRows.forEach((eventDataByEventTypeMap) -> {
                     eventDataByEventTypeMap.forEach((eventType, eventData) -> {
                         try {
+                            // eventData의 첫번째 값은 항상 targetId
                             ColumnEventType columnEventType = ColumnEventType.from(eventType);
                             List<User> subscribedSavedUser = facade.getSubscribedUsers(columnEventType, eventData.get(0));
                             List<String> processedData = facade.getProcessedData(columnEventType,eventData);
+                            if (processedData.isEmpty()) {
+                                return;
+                            }
                             String jsonString = objectMapper.writeValueAsString(processedData);
 
                             subscribedSavedUser

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -3,6 +3,7 @@ package com.everyones.lawmaking.global.util;
 import com.everyones.lawmaking.common.dto.response.NotificationResponse;
 import com.everyones.lawmaking.domain.entity.ColumnEventType;
 import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.domain.entity.ProposerKindType;
 import com.everyones.lawmaking.global.error.CommonException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -44,23 +45,40 @@ public class NotificationConverter {
         String target = data.get(0);
         String title = null;
         String content = null;
+        String extra = null;
         List<String> notificationImageUrlList = new ArrayList<>();
         switch (columnEventType) {
             case RP_INSERT:
-                // List.of(billId, billRepProposer, billProposers, billName, partyImage) <-정당이미지
+//           billId, congressmanName, billBriefSummary, partyImageUrl
                 title = data.get(1) + " 의원";
-                content = data.get(2) + "이 '" + data.get(3) + "'을/를 발의했어요!";
-                notificationImageUrlList.add(data.get(4));
+                content = "'"+data.get(2) + "'을/를 대표 발의했어요!";
+                notificationImageUrlList.add(data.get(3));
                 break;
             case BILL_STAGE_UPDATE:
-                // List.of("bill_id", "bill_name", "proposers", "stage", "partyImage") <-정당이미지
-                title = data.get(1) + "(" + data.get(2) + ")";
-                content = "스크랩한 법안이 본회의에서 '"+data.get(3)+"'되었어요!";
-                notificationImageUrlList.addAll(data.subList(4, data.size()));
+//              billId, briefSummary, stage, proposerKind, 이미지;
+                title = data.get(1);
+                content = "심사 단계가 '" + data.get(2) + "'로 변동했어요!";
+                extra = data.get(3);
+                if(data.get(3).equals(ProposerKindType.CONGRESSMAN.name())){
+                    notificationImageUrlList.addAll(data.subList(4, data.size()));
+                }else{
+                    notificationImageUrlList.add(data.get(4)+".png");
+                }
+                break;
+            case BILL_RESULT_UPDATE:
+//              billId, briefSummary, billResult, proposerKind, 이미지
+                title = data.get(1);
+                content = "'"+data.get(2) + "'로 처리되었어요!";
+                extra = data.get(3);
+                if(data.get(3).equals(ProposerKindType.CONGRESSMAN.name())){
+                    notificationImageUrlList.addAll(data.subList(4, data.size()));
+                }else{
+                    notificationImageUrlList.add(data.get(4)+".png");
+                }
                 break;
             case CONGRESSMAN_PARTY_UPDATE:
-                // List.of(congressmanId, partyName, congressmanName, partyImage); <-정당이미지
-                title = data.get(1);
+                //congressmanId, partyName, congressmanName, partyImageUrl
+                title = data.get(2);
                 content = "'"+data.get(2)+"'의원의 당적이 '"+data.get(1)+"'(으)로 변동했어요!";
                 notificationImageUrlList.add(data.get(4));
                 break;
@@ -82,6 +100,7 @@ public class NotificationConverter {
                 .title(title)
                 .content(content)
                 .createdDate(createdDate)
+                .extra(extra)
                 .build();
     }
 


### PR DESCRIPTION
## 내용
변경 사항:

1. NotificationResponse DTO에 extra 필드를 추가하여 ProposerKind를 프론트가 위원장, 의원이 발의안인지를 캐치하도록 함.
2. ColumnEventType에 새로운 이벤트 타입 BILL_RESULT_UPDATE를 추가하고, 바이너리로그에서 필요한 유니크 키만 담도록 하였습니다.
3. RP_INSERT이벤트 시, 법안 제안자의 유형을 확인하고, 제안자가 국회의원일 경우에만 알림 데이터를 반환하도록 수정했습니다.
4. updateBillStage,updateBillResult 메서드에서 법안의 proposerKind에 따라서 필요한 이미지를 의원, 위원장일때 달리 처리하였습니다.

기타 
1. 코드 컨벤션에 맞지 않는 메서드명 및 일부 로직을 리팩토링하여 가독성을 개선했습니다.
2. ColumnEventType와 메타데이터의 TableName을 소문자로 변경하여 데이터 변경을 캐치하도록 하였습니다. 이로써 로컬서버와 원격서버 둘다에서 제대로 동작하게 되었습니다.