### PR TITLE
알림 관리 기능 추가 및 리팩토링

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationCountResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationCountResponse.java
@@ -1,0 +1,26 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class NotificationCountResponse {
+    private Long userId;
+
+    private int notificationCount;
+
+
+    public static NotificationCountResponse of(Long userId, Integer notificationCount) {
+        return NotificationCountResponse.builder()
+                .userId(userId)
+                .notificationCount(notificationCount)
+                .build();
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -22,6 +22,9 @@ public class NotificationResponse {
     private String title;
 
     @NotNull
+    private Long notificationId;
+
+    @NotNull
     private String content;
 
     @NotNull
@@ -41,6 +44,10 @@ public class NotificationResponse {
     // notifications 리스트를 NotificationResponse 리스트로 만들어주는 메서드
     public static List<NotificationResponse> from(List<Notification> notifications) {
         return notifications.stream().map(NotificationConverter::from).toList();
+    }
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationConverter.from(notification);
     }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -46,8 +46,4 @@ public class NotificationResponse {
         return notifications.stream().map(NotificationConverter::from).toList();
     }
 
-    public static NotificationResponse from(Notification notification) {
-        return NotificationConverter.from(notification);
-    }
-
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
@@ -88,7 +88,7 @@ public class NotificationController {
              @RequestParam(name = "notification_id") int notificationId) {
         final UserDetails user = (UserDetails) authentication.getPrincipal();
         var result = facade.readNotification(Long.parseLong(user.getUsername()), notificationId);
-        return BaseResponse.ok(result);
+        return BaseResponse.ok(result.get(0));
     }
 
     @Operation(summary = "알림 삭제 처리 API", description = "모든 알림을 삭제 처리")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
@@ -1,9 +1,11 @@
 package com.everyones.lawmaking.controller;
 
+import com.everyones.lawmaking.common.dto.response.NotificationCountResponse;
 import com.everyones.lawmaking.common.dto.response.NotificationResponse;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,10 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -63,10 +62,95 @@ public class NotificationController {
                     )}
             ),
     })
-    @PutMapping("/read")
-    public BaseResponse<List<NotificationResponse>> readNotification(Authentication authentication) {
+    @PutMapping("/read/all")
+    public BaseResponse<List<NotificationResponse>> readAllNotifications(Authentication authentication) {
         final UserDetails user = (UserDetails) authentication.getPrincipal();
-        var result = facade.readNotifications(Long.parseLong(user.getUsername()));
+        var result = facade.readAllNotifications(Long.parseLong(user.getUsername()));
+        return BaseResponse.ok(result);
+    }
+
+    @Operation(summary = "알림 읽음 처리 API", description = "특정 알림을 읽음 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PutMapping("/read")
+    public BaseResponse<NotificationResponse> readNotification(Authentication authentication,
+             @Parameter(example = "3", description = "읽음 처리할 알림id를 의미합니다.")
+             @RequestParam(name = "notification_id") int notificationId) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.readNotification(Long.parseLong(user.getUsername()), notificationId);
+        return BaseResponse.ok(result);
+    }
+
+    @Operation(summary = "알림 삭제 처리 API", description = "모든 알림을 삭제 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @DeleteMapping("/delete/all")
+    public BaseResponse<String> deleteAllNotification(Authentication authentication) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.deleteAllNotification(Long.parseLong(user.getUsername()));
+        return BaseResponse.ok(result);
+    }
+
+    @Operation(summary = "알림 삭제 처리 API", description = "특정 알림을 삭제 처리")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @DeleteMapping("/delete")
+    public BaseResponse<String> deleteNotification(Authentication authentication,
+           @Parameter(example = "3", description = "읽음 처리할 알림id를 의미합니다.")
+           @RequestParam(name = "notification_id") int notificationId) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.deleteNotification(Long.parseLong(user.getUsername()),notificationId);
+        return BaseResponse.ok(result);
+    }
+
+
+    @Operation(summary = "새 알림 개수 조회 API", description = "알림 개수를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "읽음 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @GetMapping("/count")
+    public BaseResponse<NotificationCountResponse> countNotifications(Authentication authentication) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = facade.countNotifications(Long.parseLong(user.getUsername()));
         return BaseResponse.ok(result);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -218,9 +218,29 @@ public class Facade {
     }
 
     // 알림 읽음 처리
-    public List<NotificationResponse> readNotifications(long userId) {
-        return notificationService.readNotifications(userId);
+    public List<NotificationResponse> readAllNotifications(long userId) {
+        return notificationService.readAllNotifications(userId);
     }
+
+    public NotificationResponse readNotification(long userId, int notificationId) {
+        return notificationService.readNotification(userId, notificationId);
+    }
+
+    public String deleteAllNotification(long userId) {
+        return notificationService.deleteAllNotifications(userId);
+    }
+
+    public String deleteNotification(long userId, int notificationId) {
+        return notificationService.deleteNotification(userId, notificationId);
+    }
+
+    public NotificationCountResponse countNotifications(long userId) {
+        return notificationService.countNotifications(userId);
+    }
+
+
+
+
 
     // 알림 데이터를 각 테이블에 해당하는 실제 데이터로 변환 (ex : bill_id
     public List<String> convertRepresentativeBillNotification(List<String> uniqueKeys) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @Service
@@ -219,11 +220,11 @@ public class Facade {
 
     // 알림 읽음 처리
     public List<NotificationResponse> readAllNotifications(long userId) {
-        return notificationService.readAllNotifications(userId);
+        return notificationService.readNotification(userId, Optional.empty());
     }
 
-    public NotificationResponse readNotification(long userId, int notificationId) {
-        return notificationService.readNotification(userId, notificationId);
+    public List<NotificationResponse> readNotification(long userId, int notificationId) {
+        return notificationService.readNotification(userId, Optional.of(notificationId));
     }
 
     public String deleteAllNotification(long userId) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ErrorCode.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
 
     PARTY_NOT_FOUND(404, "해당 파티를 찾을 수 없습니다."),
 
+    NOTIFICATION_NOT_FOUND(404, "해당 알림을 찾을 수 없습니다."),
+
     // 업데이트를 위해 제공된 파라미터와 DB 내부 값이 일치하여 반환해주는 에러
     BAD_UPDATE_PARAMETER(400, "업데이트 하려는 파라미터와 DB 내부 값이 일치합니다."),
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/NotificationException.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/NotificationException.java
@@ -1,0 +1,24 @@
+package com.everyones.lawmaking.global.error;
+
+import java.util.Map;
+
+public class NotificationException extends CustomException {
+    public NotificationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public NotificationException(ErrorCode errorCode, Map<String, String> inputValueProperties) {
+        super(errorCode, inputValueProperties);
+    }
+
+    public static class NotificationNotFound extends NotificationException {
+
+        public NotificationNotFound() {
+            super(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+
+        public NotificationNotFound(Map<String, String> inputValueProperties) {
+            super(ErrorCode.NOTIFICATION_NOT_FOUND, inputValueProperties);
+        }
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -41,6 +41,7 @@ public class NotificationConverter {
     public static NotificationResponse from(Notification notification) {
         ColumnEventType columnEventType = notification.getNotificationName();
         List<String> data = parseData(notification.getContentJson());
+        Long notificationId = notification.getId();
         String type = columnEventType.getEventName();
         String target = data.get(0);
         String title = null;
@@ -94,6 +95,8 @@ public class NotificationConverter {
         return NotificationResponse.builder()
                 // 이벤트 타입
                 .type(type)
+                // 알림 id값
+                .notificationId(notificationId)
                 // 알림으로 이동할 대상 id값
                 .target(target)
                 .notificationImageUrlList(notificationImageUrlList)

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -15,10 +16,42 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
             select n
             from Notification n
-            Join User u on u.id = :userId
-            where n.user.id = :userId and n.isRead = false
+            Join n.user u
+            where u.id = :userId and n.isRead = false
             """)
-    List<Notification> findAllByUserId(@Param("userId") Long userId);
+    List<Notification> findAllUnreadNotificationsByUserId(@Param("userId") Long userId);
+
+    @Query("""
+            select n
+            from Notification n
+            Join n.user u
+            where u.id = :userId
+            """)
+    List<Notification> findAllNotificationsByUserId(@Param("userId") Long userId);
+
+    @Query("""
+            select n
+            from Notification n
+            Join n.user u
+            where u.id = :userId and n.id =:notificationId
+            """)
+    Optional<Notification> findNotificationByUserId(@Param("userId") Long userId, @Param("notificationId") int notificationId);
+
+    @Query("""
+            select n
+            from Notification n
+            Join n.user u
+            where u.id = :userId and n.id =:notificationId and n.isRead = false
+            """)
+    Optional<Notification> findUnreadNotificationByUserId(@Param("userId") Long userId, @Param("notificationId") int notificationId);
+
+    @Query("""
+            select count(n)
+            from Notification n
+            Join n.user u
+            where u.id = :userId
+            """)
+    Integer countNewNotificationsByUserId(Long userId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -1,28 +1,34 @@
 package com.everyones.lawmaking.service;
 
+import com.everyones.lawmaking.common.dto.response.NotificationCountResponse;
 import com.everyones.lawmaking.common.dto.response.NotificationResponse;
 import com.everyones.lawmaking.domain.entity.Notification;
+import com.everyones.lawmaking.global.error.NotificationException;
 import com.everyones.lawmaking.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+
+    private static final String NOTIFICATION_ID_KEY_LONG = "notificationId";
+
     public List<NotificationResponse> getNotifications(long userId){
-        List<Notification> notifications = notificationRepository.findAllByUserId(userId);
+        List<Notification> notifications = notificationRepository.findAllUnreadNotificationsByUserId(userId);
 
         return NotificationResponse.from(notifications);
     }
 
 
 
-    public List<NotificationResponse> readNotifications(long userId){
-        List<Notification> notifications = notificationRepository.findAllByUserId(userId);
+    public List<NotificationResponse> readAllNotifications(long userId){
+        List<Notification> notifications = notificationRepository.findAllUnreadNotificationsByUserId(userId);
 
         notifications.forEach((noti)-> noti.setRead(true));
 
@@ -30,4 +36,37 @@ public class NotificationService {
 
         return NotificationResponse.from(notificationsRead);
     }
+    public NotificationResponse readNotification(long userId, int notificationId){
+        Notification notification = notificationRepository.findUnreadNotificationByUserId(userId, notificationId)
+                .orElseThrow(() -> new NotificationException.NotificationNotFound(Map.of(NOTIFICATION_ID_KEY_LONG, String.valueOf(notificationId))));
+        notification.setRead(true);
+        Notification notificationsRead = notificationRepository.save(notification);
+
+        return NotificationResponse.from(notificationsRead);
+    }
+
+    public String deleteAllNotifications(long userId){
+        List<Notification> notifications = notificationRepository.findAllNotificationsByUserId(userId);
+
+        notificationRepository.deleteAll(notifications);
+        return "success";
+    }
+
+    public String deleteNotification(long userId, int notificationId){
+        Notification notification = notificationRepository.findNotificationByUserId(userId, notificationId)
+                .orElseThrow(() -> new NotificationException.NotificationNotFound(Map.of(NOTIFICATION_ID_KEY_LONG, String.valueOf(notificationId))));
+
+
+        notificationRepository.delete(notification);
+        return "success";
+    }
+
+    public NotificationCountResponse countNotifications(long userId){
+        Integer notification = notificationRepository.countNewNotificationsByUserId(userId);
+        return NotificationCountResponse.of(userId, notification);
+    }
+
+
+
+
 }


### PR DESCRIPTION
## 내용

1. NotificationCountResponse DTO 추가
사용자 ID(userId)와 알림 개수(notificationCount)를 포함하는 응답 객체.
빌더 패턴을 사용해 객체를 생성하며, JSON 응답에서 snake_case 포맷을 사용하도록 설정.

2. [NotificationResponse DTO 확장]
notificationId 필드를 추가하여 알림의 고유 ID를 반환하도록 수정.
NotificationConverter를 통해 Notification 엔티티를 DTO로 변환하는 기능 추가.
알림 읽기 및 삭제 API 추가

3. 새로운 API 추가
모든 알림 읽기: /read/all 엔드포인트에서 모든 알림을 읽음 처리.
특정 알림 읽기: /read 엔드포인트에서 특정 알림(notification_id)만 읽음 처리.
모든 알림 삭제: /delete/all 엔드포인트에서 모든 알림 삭제.
특정 알림 삭제: /delete 엔드포인트에서 특정 알림(notification_id)만 삭제.
알림 개수 조회 API 추가
<읽기>
readNotification 메서드를 통해 모든 알림 또는 특정 알림을 읽음 처리하도록 통합.
<삭제>
deleteAllNotification 및 deleteNotification 메서드를 추가해 알림 삭제 기능 구현.
<카운트>
countNotifications 메서드를 추가해 알림 개수를 조회하는 기능 구현.

4. 예외 처리 강화
NotificationNotFound 예외 클래스를 추가해 알림을 찾지 못했을 때의 예외 상황을 처리.
예외 발생 시 적절한 오류 메시지를 반환하도록 개선.