### PR TITLE
PR 제목 BillRepository 및 관련 서비스 리팩토링

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -32,6 +32,8 @@ public class NotificationResponse {
 
     private String extra;
 
+    private boolean isRead;
+
     @NotNull
     private List<String> notificationImageUrlList;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -44,6 +44,7 @@ public class NotificationConverter {
         Long notificationId = notification.getId();
         String type = columnEventType.getEventName();
         String target = data.get(0);
+        boolean isRead = notification.isRead();
         String title = null;
         String content = null;
         String extra = null;
@@ -98,6 +99,7 @@ public class NotificationConverter {
                 // 알림 id값
                 .notificationId(notificationId)
                 // 알림으로 이동할 대상 id값
+                .isRead(isRead)
                 .target(target)
                 .notificationImageUrlList(notificationImageUrlList)
                 .title(title)

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -27,11 +27,9 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findByPage(Pageable pageable, @Param("stage") String stage);
 
     // 특정 의원이 대표 발의한 법안들
-    @Query("SELECT distinct b FROM Bill b " +
-           "JOIN b.representativeProposer rp " +
-           "WHERE b.id = rp.bill.id " +
-           "AND rp.congressman.id = :congressmanId " +
-            "ORDER BY b.proposeDate desc, b.id desc ")
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select rp FROM b.representativeProposer rp where rp.congressman.id = :congressmanId) " +
+            "ORDER BY b.proposeDate desc, b.id desc")
     Slice<Bill> findByRepresentativeProposer(String congressmanId, Pageable pageable);
 
     // 특정의원이 공동 발의한 법안들
@@ -41,12 +39,9 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findBillByPublicProposer(String congressmanId, Pageable pageable);
 
     // 정당 소속 의원들이 대표 발의한 법안
-    @Query("SELECT distinct b FROM Bill b " +
-            "JOIN b.representativeProposer rp " +
-            "JOIN rp.congressman c " +
-            "JOIN c.party p " +
-            "WHERE p.id = :partyId " +
-            "ORDER BY b.proposeDate desc, b.id desc")
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select rp FROM b.representativeProposer rp where rp.congressman.party.id = :partyId) " +
+            "ORDER BY b.proposeDate DESC, b.id DESC")
     Slice<Bill> findRepresentativeBillsByParty(Pageable pageable, @Param("partyId") long partyId);
 
     // 정당 소속 의원들이 공동 발의한 법안
@@ -57,36 +52,25 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<Bill> findPublicBillsByParty(Pageable pageable, @Param("partyId") long partyId);
 
     // 유저가 스크랩한 법안 페이징해서 가져오는 쿼리
-    @Query("SELECT distinct b FROM Bill b " +
-            "JOIN b.representativeProposer rp " +
+    @Query("SELECT b FROM Bill b " +
             "JOIN b.billLike bl " +
             "JOIN bl.user u " +
-            "where u.id = :userId " +
-            "order by b.proposeDate desc")
+            "WHERE u.id = :userId " +
+            "ORDER BY b.proposeDate DESC, b.id desc")
     Slice<Bill> findByUserId(Pageable pageable, @Param("userId") long userId);
 
     // 단일 법안과 관련된 정보 가져오는 쿼리
-    @Query("SELECT distinct b FROM Bill b " +
-            "JOIN b.representativeProposer rp " +
-            "JOIN rp.congressman rpc " +
-            "JOIN rpc.party rpp " +
-            "WHERE b.id = :billId "
-    )
-    Optional<Bill> findBillInfoById(String billId);
+    Optional<Bill> findBillById(String billId);
+
 
     // 피드 등 여러 법안들 가져오는 쿼리
-    @Query("SELECT DISTINCT b FROM Bill b " +
-            "JOIN b.publicProposer bp " +
-            "JOIN bp.congressman bpc " +
-            "JOIN bpc.party bpp " +
+    @Query("SELECT b FROM Bill b " +
             "WHERE b.id in :billList " +
-            "ORDER BY b.proposeDate desc, b.id"
-    )
+            "ORDER BY b.proposeDate desc, b.id desc")
     List<Bill> findBillInfoByIdList(List<String> billList);
 
     // 유사한 법안 조회 법안과 같은 이름을 가진 법안 조회
-    @Query("SELECT distinct b FROM Bill b " +
-            "JOIN b.representativeProposer rp " +
+    @Query("SELECT b FROM Bill b " +
             "WHERE b.billName = :billName " +
             "AND b.id != :billId ")
     List<Bill> findSimilarBills(@Param("billName") String billName, @Param("billId") String billId);
@@ -104,17 +88,14 @@ public interface BillRepository extends JpaRepository<Bill, String> {
     Slice<String> findBillByKeyword(Pageable pageable,@Param("keyword") String keyword);
 
 
-    Optional<Bill> findBillById(String billNumber);
 
     @Query("select distinct b from Bill b " +
             "JOIN b.representativeProposer rp " +
             "JOIN rp.congressman c " +
             "JOIN c.congressmanLike cl " +
             "where cl.user.id = :userId " +
-            "ORDER BY b.proposeDate desc ")
+            "ORDER BY b.proposeDate desc, b.id desc")
     Slice<Bill> findByUserAndCongressmanLike(Pageable pageable, long userId);
-    @Query("SELECT b FROM Bill b WHERE b.id IN :billIds")
-    List<Bill> findByBillIdIn(@Param("billIds") List<String> billIds);
 
     @Query("SELECT DISTINCT b FROM Bill b " +
             "JOIN FETCH b.representativeProposer rp " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/VoteRecordRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/VoteRecordRepository.java
@@ -10,10 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface VoteRecordRepository extends JpaRepository<VoteRecord,Long> {
-    @Query("select vr.id from VoteRecord vr " +
-            "join vr.bill b " +
-            "where b.id =:billId ")
-    Optional<Long> findVoteRecordIdByBillId(@Param("billId") String billId);
 
     @Query("select vr from VoteRecord vr " +
             "where vr.bill.id = :billId ")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -46,7 +46,7 @@ public class BillService {
     }
 
     public BillDetailResponse getBillWithDetail(String billId) {
-        var bill = billRepository.findBillInfoById(billId)
+        var bill = billRepository.findBillById(billId)
                 .orElseThrow(() -> new BillException.BillNotFound(Map.of(BILL_ID_KEY_STRING, billId)));
 
         var billDetailResponse = getBillDetailInfoFrom(bill);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -36,7 +36,7 @@ public class DataService {
         // 시점 파티 데이터 넣기
         billDfRequestList
             .forEach(billDfRequest -> {
-                var oldBill = billRepository.findBillInfoById(billDfRequest.getBillId())
+                var oldBill = billRepository.findBillById(billDfRequest.getBillId())
                         .orElse(null);
                 if (oldBill != null){
                     oldBill.updateContent(billDfRequest);
@@ -95,7 +95,7 @@ public class DataService {
         billStageDfRequestList.forEach(
                 billStageDfRequest -> {
                     var billId = billStageDfRequest.getBillId();
-                    var foundBill = billRepository.findBillInfoById(billId)
+                    var foundBill = billRepository.findBillById(billId)
                             .orElse(null);
                     var equalBill = billTimelineRepository.findBillTimelineByInfo(billStageDfRequest.getBillId(),
                             billStageDfRequest.getActStatusValue(),
@@ -188,16 +188,16 @@ public class DataService {
 
         voteDfRequestList.forEach((voteDfRequest)->{
             var billId = voteDfRequest.getBillId();
-            var foundBill = billRepository.findBillInfoById(billId)
+            var foundBill = billRepository.findBillById(billId)
                     .orElse(null);
             if (foundBill == null) {
                 result.add(billId);
             }
             else{
-                var voteRecordId = voteRecordRepository.findVoteRecordIdByBillId(foundBill.getId());
-                if(voteRecordId.isEmpty()){
-                    var voteRecord = VoteRecord.of(foundBill, voteDfRequest);
-                    voteRecordRepository.save(voteRecord);
+                var voteRecord = voteRecordRepository.findVoteRecordByBillId(foundBill.getId());
+                if(voteRecord.isEmpty()){
+                    var newVoteRecord = VoteRecord.of(foundBill, voteDfRequest);
+                    voteRecordRepository.save(newVoteRecord);
                 }
             }
         });
@@ -211,7 +211,7 @@ public class DataService {
         votePartyRequestList.forEach((votePartyRequest)->{
             var party = partyRepository.findPartyByName(votePartyRequest.getPartyName())
                     .orElse(null);
-            var foundBill = billRepository.findBillInfoById(votePartyRequest.getBillId())
+            var foundBill = billRepository.findBillById(votePartyRequest.getBillId())
                     .orElse(null);
 
             if (party == null || foundBill == null) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -21,7 +21,7 @@ public class NotificationService {
     private static final String NOTIFICATION_ID_KEY_LONG = "notificationId";
 
     public List<NotificationResponse> getNotifications(long userId){
-        List<Notification> notifications = notificationRepository.findAllUnreadNotificationsByUserId(userId);
+        List<Notification> notifications = notificationRepository.findAllNotificationsByUserId(userId);
 
         return NotificationResponse.from(notifications);
     }


### PR DESCRIPTION
## 내용
1. BillRepository.java 리팩토링
쿼리 최적화:
복잡한 JOIN 구문을 EXISTS 절로 대체하여 쿼리의 간결성과 성능을 개선.

findBillInfoById 메서드를 findBillById로 변경하여 불필요한 JOIN 제거.

ORDER BY 절에 b.id desc를 추가하여 정렬의 일관성 유지.
-> 스크랩 중복 문제 해결

불필요한 메서드 제거:
중복되거나 사용되지 않는 메서드 삭제로 코드 정리.

2. VoteRecordRepository.java 수정
메서드 정리:
findVoteRecordIdByBillId 메서드 제거하여 코드 간소화.

3. 서비스 클래스 리팩토링
BillService.java:
billRepository.findBillInfoById 호출을 billRepository.findBillById로 변경.
DataService.java:
billRepository.findBillInfoById 호출을 billRepository.findBillById로 변경.
voteRecord 처리 로직 수정:
기존의 voteRecordId 조회 -> voteRecord조회