### PR TITLE
알림 처리 및 각종 이미지 정보 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -51,13 +51,18 @@ public class NotificationConverter {
         List<String> notificationImageUrlList = new ArrayList<>();
         switch (columnEventType) {
             case RP_INSERT:
-//           billId, congressmanName, billBriefSummary, partyImageUrl
+                //의원 발의
+//           billId, congressmanName, billBriefSummary, congressmanInfo, partyInfo
                 title = data.get(1) + " 의원";
                 content = "'"+data.get(2) + "'을/를 대표 발의했어요!";
-                notificationImageUrlList.add(data.get(3));
+                notificationImageUrlList.addAll(data.subList(3, data.size()));
                 break;
             case BILL_STAGE_UPDATE:
-//              billId, briefSummary, stage, proposerKind, 이미지;
+                //의원 발의
+//              billId, briefSummary, stage, proposerKind.name()), partyInfoList.stream();
+
+                //위원장 발의
+//                billId, briefSummary, stage, proposerKind.name(),proposers
                 title = data.get(1);
                 content = "심사 단계가 '" + data.get(2) + "'로 변동했어요!";
                 extra = data.get(3);
@@ -68,7 +73,10 @@ public class NotificationConverter {
                 }
                 break;
             case BILL_RESULT_UPDATE:
-//              billId, briefSummary, billResult, proposerKind, 이미지
+                //의원 발의
+//              billId, briefSummary, billResult, proposerKind.name()), partyInfoList.stream()
+                //위원장 발의
+//                billId, briefSummary, billResult, proposerKind.name(), proposers
                 title = data.get(1);
                 content = "'"+data.get(2) + "'로 처리되었어요!";
                 extra = data.get(3);
@@ -79,10 +87,10 @@ public class NotificationConverter {
                 }
                 break;
             case CONGRESSMAN_PARTY_UPDATE:
-                //congressmanId, partyName, congressmanName, partyImageUrl
+                //congressmanId, partyName, congressmanName,congressmanInfo, partyInfo
                 title = data.get(2);
                 content = "'"+data.get(2)+"'의원의 당적이 '"+data.get(1)+"'(으)로 변동했어요!";
-                notificationImageUrlList.add(data.get(4));
+                notificationImageUrlList.addAll(data.subList(3, data.size()));
                 break;
         }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
@@ -18,6 +18,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             from Notification n
             Join n.user u
             where u.id = :userId and n.isRead = false
+            order by n.createdDate desc
             """)
     List<Notification> findAllUnreadNotificationsByUserId(@Param("userId") Long userId);
 
@@ -26,8 +27,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             from Notification n
             Join n.user u
             where u.id = :userId
+            order by n.createdDate desc
             """)
-    List<Notification> findAllNotificationsByUserId(@Param("userId") Long userId);
+    List<Notification> findAllNotificationsByUserIdSorted(@Param("userId") Long userId);
+
+    @Query("""
+            select n
+            from Notification n
+            Join n.user u
+            where u.id = :userId
+            """)
+    List<Notification> findAllNotificationsByUser(@Param("userId") Long userId);
 
     @Query("""
             select n

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyRepository.java
@@ -28,12 +28,12 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     List<Party> findBySearchWord(@Param("searchWord") String searchWord);
 
 
-    @Query("SELECT distinct p.partyImageUrl " +
+    @Query("SELECT distinct p " +
             "from Party p " +
-            "join Congressman c on c.party.id = p.id " +
-            "join RepresentativeProposer rp on rp.congressman.id =c.id " +
+            "join p.congressmanList c " +
+            "join c.representativeProposer rp " +
             "where rp.bill.id =:billId")
-    List<String> findPartyByBillId(@Param("billId") String billId);
+    List<Party> findPartyByBillId(@Param("billId") String billId);
 
     Optional<Party> findPartyByName(String partyName);
     @Query("SELECT new com.everyones.lawmaking.common.dto.response.ParliamentaryPartyResponse(p.id, p.name, p.partyImageUrl, COUNT(c)) " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -21,7 +21,7 @@ public class NotificationService {
     private static final String NOTIFICATION_ID_KEY_LONG = "notificationId";
 
     public List<NotificationResponse> getNotifications(long userId){
-        List<Notification> notifications = notificationRepository.findAllNotificationsByUserId(userId);
+        List<Notification> notifications = notificationRepository.findAllNotificationsByUserIdSorted(userId);
 
         return NotificationResponse.from(notifications);
     }
@@ -49,7 +49,7 @@ public class NotificationService {
     }
 
     public String deleteAllNotifications(long userId){
-        List<Notification> notifications = notificationRepository.findAllNotificationsByUserId(userId);
+        List<Notification> notifications = notificationRepository.findAllNotificationsByUser(userId);
 
         notificationRepository.deleteAll(notifications);
         return "success";

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
@@ -49,12 +49,22 @@ public class PartyService {
                 .collect(Collectors.toList());
     }
 
-    public List<String> getPartyByBillId(String billId) {
-        List<String> partyImageList = partyRepository.findPartyByBillId(billId);
-        if (partyImageList.isEmpty()) {
+    public List<Party> getPartyListByBillId(String billId) {
+        List<Party> partyList = partyRepository.findPartyByBillId(billId);
+        if (partyList.isEmpty()) {
             throw new PartyException.PartyNotFound(Map.of("billId", billId));
         }
-        return partyImageList;
+        return partyList;
+
+    }
+
+    public List<String> getPartyInfoList(String billId) {
+        List<Party> partyList = getPartyListByBillId(billId);
+        return partyList.stream().map(party -> {
+            var partyName = party.getName();
+            var partyImageUrl = party.getPartyImageUrl();
+            return "정당:"+partyName + ":" + partyImageUrl;
+        }).toList();
 
     }
 


### PR DESCRIPTION
## 내용
이번 PR에서는 법안 시스템의 알림 및 정당 정보 처리 관련 여러 개선 사항과 리팩토링을 포함하고 있습니다. 코드의 가독성과 성능을 향상시키며 유지보수성을 높이는 것을 목표로, 알림 데이터 처리와 정당 정보 조회 로직이 개선되었습니다. 또한, 일부 메서드의 명칭이 기능에 맞게 변경되었습니다.

주요 변경 사항:
Facade.java:

메서드 convertRepresentativeBillNotification을 insertRepresentativeBill로 변경하여 메서드의 기능을 더 명확하게 반영.
알림 데이터에 congressmanInfo와 partyInfo를 추가하여 더 풍부한 정보를 제공. null-safe 처리 추가.
중복되던 정당 이미지 조회 로직을 partyService.getPartyInfoList()로 통일하여 간소화.
NotificationConverter.java:

알림 데이터 처리 시 확장된 정보(의원 및 정당 정보)를 반영하도록 수정.
기존의 단일 이미지 URL 처리에서 여러 이미지 URL을 처리할 수 있도록 개선.
NotificationRepository.java:

알림 조회 시 정렬 기능을 개선:
findAllUnreadNotificationsByUserId와 findAllNotificationsByUserId에 createdDate로 정렬 기능 추가.
정렬이 필요 없는 경우를 위해 findAllNotificationsByUser 메서드 추가.
PartyRepository.java:

findPartyByBillId 쿼리가 정당 이미지 URL만 반환하던 것을 전체 Party 엔티티를 반환하도록 수정.
엔티티 간 관계를 활용하여 쿼리 성능과 가독성을 개선.
NotificationService.java:

리포지토리 메서드 (findAllNotificationsByUserIdSorted 및 findAllNotificationsByUser)를 사용하도록 서비스 로직 업데이트.
PartyService.java:

getPartyByBillId 메서드를 정당 이미지 URL이 아닌 전체 Party 객체 목록을 반환하도록 변경.
알림에서 사용할 정당 정보(이름 및 이미지 URL)를 반환하는 getPartyInfoList 메서드 추가.