### PR TITLE
#Feat(#Bill-Detail) 개별 법안에 대해 투표기록 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/VoteResultResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/VoteResultResponse.java
@@ -1,0 +1,35 @@
+package com.everyones.lawmaking.common.dto;
+
+import com.everyones.lawmaking.domain.entity.VoteRecord;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class VoteResultResponse {
+    private Integer approvalCount;
+    private Integer totalVoteCount;
+    private List<PartyVoteDto> partyVoteList;
+
+    public static VoteResultResponse of(VoteRecord voteRecord, List<PartyVoteDto> partyVoteList) {
+        var voteResultBuilder = VoteResultResponse.builder()
+                .partyVoteList(partyVoteList);
+        if (voteRecord == null) {
+            return voteResultBuilder.build();
+        }
+
+        return voteResultBuilder
+                .approvalCount(voteRecord.getVoteForCount())
+                .totalVoteCount(voteRecord.getTotalVoteCount())
+                .build();
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillDetailResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillDetailResponse.java
@@ -1,6 +1,7 @@
 package com.everyones.lawmaking.common.dto.response;
 
 import com.everyones.lawmaking.common.dto.*;
+import com.everyones.lawmaking.domain.entity.VoteRecord;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
@@ -14,6 +15,7 @@ import java.util.List;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BillDetailResponse extends BillDto {
     private List<SimilarBill> similarBills;
+    private VoteResultResponse voteResultResponse;
 
 
     public BillDetailResponse(@NotNull BillInfoDto billInfoDto, @NotNull List<RepresentativeProposerDto> representativeProposerDto, @NotNull List<PublicProposerDto> publicProposerDtoList, @NotNull Boolean isBookMarked) {
@@ -22,5 +24,9 @@ public class BillDetailResponse extends BillDto {
 
     public void setSimilarBills(List<SimilarBill> similarBills) {
         this.similarBills = similarBills;
+    }
+
+    public void setVoteResultResponse(VoteResultResponse voteResultResponse) {
+        this.voteResultResponse = voteResultResponse;
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -63,8 +63,14 @@ public class Facade {
         if (userId.isEmpty()) {
             return billDto;
         }
+        var voteRecord = voteRecordService.getVoteRecordByBillId(billId);
+        var votePartyList = votePartyService.getVotePartyListWithPartyByBillId(billId).stream()
+                .map(PartyVoteDto::from)
+                .toList();
+        var voteResultResponse = VoteResultResponse.of(voteRecord, votePartyList);
         var isBookMark = likeService.getBillLikeChecked(billDto.getBillInfoDto().getBillId(), userId.get());
         billDto.setIsBookMark(isBookMark);
+        billDto.setVoteResultResponse(voteResultResponse);
         return billDto;
     }
 
@@ -443,7 +449,6 @@ public class Facade {
                     plenaryBills.add(plenaryBill);
                 });
         return plenaryBills;
-
     }
 
     public List<CommitteeAuditDto> getCommitteeBills(LocalDate proposeDate) {
@@ -460,6 +465,8 @@ public class Facade {
                 .toList();
 
     }
+
+
 
 
     public List<ParliamentaryPartyResponse> getParliamentaryParty() {


### PR DESCRIPTION
## 내용

VoteResultResponse 클래스 추가:

투표 결과 정보를 담는 DTO 클래스입니다.
승인 수(approvalCount), 총 투표 수(totalVoteCount), 정당별 투표 정보(partyVoteList)를 포함합니다.
VoteRecord 엔티티와 정당별 투표 리스트(List<PartyVoteDto>)를 받아 투표 결과를 생성하는 of() 메서드가 있습니다.

BillDetailResponse 클래스 수정:

VoteResultResponse 필드를 추가하여 법안 상세 정보에 투표 결과를 포함할 수 있게 변경되었습니다.
setVoteResultResponse 메서드 추가로 투표 결과 데이터를 설정할 수 있습니다.

Facade 클래스 수정:

voteRecordService와 votePartyService를 통해 특정 법안의 투표 기록과 정당별 투표 정보를 가져오고, 이를 VoteResultResponse로 변환해 BillDetailResponse에 설정하는 로직이 추가되었습니다.