### PR TITLE
법안 처리 및 의원 조회 로직 리팩토링

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/BillDfRequest.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/request/BillDfRequest.java
@@ -2,7 +2,6 @@ package com.everyones.lawmaking.common.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Builder
 public class BillDfRequest {
     private String billId;
 
@@ -21,6 +19,8 @@ public class BillDfRequest {
     private String billName;
 
     private String stage;
+
+    private String billResult;
 
     private int assemblyNumber;
 
@@ -35,11 +35,9 @@ public class BillDfRequest {
 
     private String proposers;
 
-    private List<String> publicProposers;
+    private List<String> publicProposerIdList;
 
-    private List<String> rstProposerNameList;
-
-    private List<String> rstProposerPartyNameList;
+    private List<String> rstProposerIdList;
 
     private String proposerKind;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -31,11 +31,6 @@ import java.util.List;
     @Column(name = "bill_number", unique = true)
     private int billNumber;
 
-    // 법안의 제안시점 정당 데이터용으로 partyId 필요
-    @Column(name = "partyIdList")
-    @ElementCollection(fetch = FetchType.LAZY)
-    private List<Long> partyIdList;
-
     @NotNull
     @Column(name = "assembly_number")
     private int assemblyNumber;
@@ -98,11 +93,11 @@ import java.util.List;
     @OneToMany(mappedBy = "bill")
     private List<BillTimeline> billTimelineList = new ArrayList<>();
 
-    public static Bill of(BillDfRequest billDfRequest,List<Long> partyIdList){
+    public static Bill of(BillDfRequest billDfRequest){
         return Bill.builder()
                 .id(billDfRequest.getBillId())
+                .billResult(billDfRequest.getBillResult())
                 .billNumber(billDfRequest.getBillNumber())
-                .partyIdList(partyIdList)
                 .billName(billDfRequest.getBillName())
                 .proposeDate(billDfRequest.getProposeDate())
                 .proposers(billDfRequest.getProposers())
@@ -116,9 +111,18 @@ import java.util.List;
     }
 
     public void updateContent(BillDfRequest billDfRequest){
-        this.setSummary(billDfRequest.getSummary());
+        this.setBillResult(billDfRequest.getBillResult());
+        this.setBillNumber(billDfRequest.getBillNumber());
+        this.setBillName(billDfRequest.getBillName());
+        this.setProposeDate(billDfRequest.getProposeDate());
+        this.setProposers(billDfRequest.getProposers());
+        this.setAssemblyNumber(billDfRequest.getAssemblyNumber());
+        this.setStage(billDfRequest.getStage());
         this.setGptSummary(billDfRequest.getGptSummary());
+        this.setSummary(billDfRequest.getSummary());
         this.setBriefSummary(billDfRequest.getBriefSummary());
+        this.setProposerKind(ProposerKindType.from(billDfRequest.getProposerKind()));
+
     }
 
     public void updateStatusByStep(BillStageDfRequest billStageDfRequest){

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
@@ -1,7 +1,6 @@
 package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.Congressman;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -36,8 +35,8 @@ public interface CongressmanRepository extends JpaRepository<Congressman, String
     Slice<Congressman> findByPartyId(@Param("partyId") long partyId);
 
     @Query("SELECT c FROM Congressman c " +
-            "Where c.state = true and c.name =:congressmanName ")
-    Optional<Congressman> findLawmakerByName(String congressmanName);
+            "Where c.state = true and c.name =:congressmanId ")
+    Optional<Congressman> findLawmakerById(String congressmanId);
 
 
     Optional<Congressman> findCongressmanById(String congressmanId);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -60,8 +60,8 @@ public class DataService {
                                     }
                             );
                     //대표발의자 이름 검색해서 RP 찾기
-                    var representativeProposerName = billDfRequest.getRstProposerIdList();
-                    representativeProposerName.forEach((rpID) -> {
+                    billDfRequest.getRstProposerIdList().
+                            forEach((rpID) -> {
                         var representativeProposer = congressmanRepository.findLawmakerById(rpID)
                                 .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", rpID)));
                         updateRepresentativeProposer(newBill, representativeProposer);


### PR DESCRIPTION
## 내용:
이번 PR은 법안 요청 및 리포지토리 처리 로직을 리팩토링하여, 더 이상 사용되지 않는 필드를 제거하고 메서드 작동 방식을 개선함으로써 코드의 명확성과 효율성을 높였습니다. 또한 Bill 및 Congressman 엔티티를 새로운 요구 사항에 맞게 수정하고, 기존 로직의 오류 처리 및 엔티티 매핑 방식을 개선했습니다.

주요 변경 사항:
BillDfRequest.java:

@Builder 어노테이션 제거.
새로운 필드 billResult 추가.
필드 변경:
publicProposers → publicProposerIdList로 변경.
rstProposerNameList → rstProposerIdList로 변경.
Bill.java:

partyIdList 필드 제거 (더 이상 필요하지 않음).
of 메서드에서 partyIdList 매개변수 제거.
updateContent 메서드 확장: billResult, billNumber 등 추가된 필드를 처리하도록 수정.
CongressmanRepository.java:

findLawmakerByName 메서드를 findLawmakerById로 변경, 이름 기반 조회에서 ID 기반 조회로 전환하여 정확성을 높임.
DataService.java:

정당 이름으로부터 정당 ID를 조회하는 로직 제거. 이제 publicProposerIdList 및 rstProposerIdList를 통해 발의자와 대표 발의자를 직접 ID로 처리.
불필요한 정당 조회를 제거하여 법안 생성 플로우 단순화.
billProposerUpdate 및 updateRepresentativeProposer 메서드에서 발의자 조회 시 이름 대신 ID로 처리하도록 리팩토링.