### PR TITLE
Feat(#Recent-Search-Word) 최근 검색어 기능 구현 완료

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/SearchKeywordResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/SearchKeywordResponse.java
@@ -1,0 +1,24 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.everyones.lawmaking.domain.entity.SearchKeyword;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SearchKeywordResponse {
+
+    private String searchWord;
+
+    public static SearchKeywordResponse from(SearchKeyword searchKeyword) {
+        return SearchKeywordResponse.builder()
+                .searchWord(searchKeyword.getSearchWord())
+                .build();
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/SearchController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.controller;
 
 import com.everyones.lawmaking.common.dto.response.SearchBillResponse;
 import com.everyones.lawmaking.common.dto.response.SearchDataResponse;
+import com.everyones.lawmaking.common.dto.response.SearchKeywordResponse;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.BaseResponse;
 import com.everyones.lawmaking.global.error.BillException;
@@ -16,11 +17,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
@@ -33,6 +32,66 @@ public class SearchController {
 
     private final Facade facade;
 
+    @Operation(summary = "최근 검색어 삽입 API", description = "최근 10개의 검색어를 가져옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @PostMapping("/recent-keword")
+    public BaseResponse<String> makeRecentKeyword(
+            @Parameter(example = "국민", description = "국민의 힘 정당 노리는 검색어")
+            @RequestParam("search_word") String searchWord) {
+        facade.makeSearchKeywordAndGetRecentSearchWords(searchWord);
+        return BaseResponse.ok(searchWord + "업데이트 완료");
+    }
+
+    @Operation(summary = "최근 검색어 제공 API", description = "최근 10개의 검색어를 가져옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @GetMapping("/recent-keword")
+    public BaseResponse<List<SearchKeywordResponse>> getRecentSearchWords() {
+        var result = facade.getRecentSearchWords();
+        return BaseResponse.ok(result);
+    }
+
+    @Operation(summary = "최근 검색어 삭제 API", description = "검색어 삭제 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @DeleteMapping("/recent-keword")
+    public BaseResponse<String> removeRecentKeyword(
+            @Parameter(example = "국민", description = "국민의 힘 정당 노리는 검색어")
+            @RequestParam("search_word") String searchWord) {
+        facade.removeRecentSearchWord(searchWord);
+        return BaseResponse.ok(searchWord + "가 삭제되었습니다. ");
+    }
     // 의원, 정당 검색
 
     @Operation(summary = "의원 및 정당 검색", description = "의원 또는 정당 탭에서 검색한 결과를 주는 API입니다. ")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BaseEntity.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/BaseEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
+@Data
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/SearchKeyword.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/SearchKeyword.java
@@ -1,0 +1,32 @@
+package com.everyones.lawmaking.domain.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Data
+@ToString
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Table(name = "SearchKeyword", indexes = {
+        @Index(name = "idx_search_word_word_modified_date", columnList = "search_word, modified_date")},
+        uniqueConstraints = @UniqueConstraint(name = "uc_user_id_search_word", columnNames = {"search_word", "user_id"})
+)
+public class SearchKeyword extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "search_word")
+    private String searchWord;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -7,6 +7,7 @@ import com.everyones.lawmaking.domain.entity.ColumnEventType;
 import com.everyones.lawmaking.domain.entity.ProposerKindType;
 import com.everyones.lawmaking.domain.entity.User;
 import com.everyones.lawmaking.global.error.AuthException;
+import com.everyones.lawmaking.global.error.UserException;
 import com.everyones.lawmaking.global.util.AuthenticationUtil;
 import com.everyones.lawmaking.global.util.NullUtil;
 import com.everyones.lawmaking.service.*;
@@ -44,6 +45,7 @@ public class Facade {
     private final BillTimelineService billTimelineService;
     private final VotePartyService votePartyService;
     private final VoteRecordService voteRecordService;
+    private final SearchKeywordService searchKeywordService;
 
     public BillListResponse findByPage(Pageable pageable) {
         var billListResponse = billService.findByPage(pageable);
@@ -466,6 +468,25 @@ public class Facade {
 
     }
 
+    public List<SearchKeywordResponse> getRecentSearchWords() {
+        var userId = AuthenticationUtil.getUserId()
+                .orElseThrow(UserException.UserNotFoundException::new);
+        return searchKeywordService.getRecentSearchWords(userId);
+    }
+
+    public void makeSearchKeywordAndGetRecentSearchWords(String keyword) {
+        var userId = AuthenticationUtil.getUserId()
+                        .orElseThrow(UserException.UserNotFoundException::new);
+
+        var user = userService.findById(userId);
+        searchKeywordService.makeSearchKeyword(user, keyword);
+    }
+
+    public void removeRecentSearchWord(String keyword) {
+        var userId = AuthenticationUtil.getUserId()
+                        .orElseThrow(UserException.UserNotFoundException::new);
+        searchKeywordService.removeRecentSearchWord(userId, keyword);
+    }
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/GlobalExceptionHandler.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/GlobalExceptionHandler.java
@@ -22,7 +22,8 @@ public class GlobalExceptionHandler {
 
     // 404 NotFound 에러
     @ExceptionHandler({PartyException.PartyNotFound.class,
-                        VoteRecordException.VoteRecordNotFound.class})
+                        VoteRecordException.VoteRecordNotFound.class,
+                        UserException.UserNotFoundException.class})
     protected ResponseEntity<ErrorResponse> handleGlobalNotFoundException(final CustomException e) {
 
         log.error(e.getErrorInfoLog());

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/SearchKeywordRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/SearchKeywordRepository.java
@@ -1,0 +1,21 @@
+package com.everyones.lawmaking.repository;
+
+import com.everyones.lawmaking.domain.entity.SearchKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SearchKeywordRepository extends JpaRepository<SearchKeyword, Long> {
+
+    // 특정 사용자의 최근 검색어 목록 조회
+    List<SearchKeyword> findTop10ByUserIdOrderByModifiedDateDesc(Long userId);
+
+    Optional<SearchKeyword> findByUserIdAndSearchWord(Long userId, String searchWord);
+
+    void deleteByUserIdAndSearchWord(Long userId, String searchWord);
+
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/SearchKeywordService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/SearchKeywordService.java
@@ -1,0 +1,56 @@
+package com.everyones.lawmaking.service;
+
+import com.everyones.lawmaking.common.dto.response.SearchKeywordResponse;
+import com.everyones.lawmaking.domain.entity.SearchKeyword;
+import com.everyones.lawmaking.domain.entity.User;
+import com.everyones.lawmaking.repository.SearchKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchKeywordService {
+    private final SearchKeywordRepository searchKeywordRepository;
+
+    // 있으면 추가하고 없으면 넣고
+    @Transactional
+    public void makeSearchKeyword(User user, String keyWord) {
+        var searchKeywordOptional = searchKeywordRepository.findByUserIdAndSearchWord(user.getId(), keyWord);
+        if(searchKeywordOptional.isPresent()) {
+            updateRecentSearchKeyword(searchKeywordOptional.get());
+        } else {
+            saveRecentSearchKeyword(user, keyWord);
+        }
+    }
+
+    public void updateRecentSearchKeyword(SearchKeyword searchKeyword) {
+        searchKeyword.setModifiedDate(LocalDateTime.now());
+        searchKeywordRepository.save(searchKeyword);
+
+    }
+
+    public void saveRecentSearchKeyword(User user, String keyword) {
+        var searchKeyword = SearchKeyword.builder()
+                .searchWord(keyword)
+                .user(user)
+                .modifiedDate(LocalDateTime.now())
+                .build();
+        searchKeywordRepository.save(searchKeyword);
+    }
+    @Transactional
+    public void removeRecentSearchWord(Long userId, String keyword) {
+        searchKeywordRepository.deleteByUserIdAndSearchWord(userId, keyword);
+    }
+
+    // 최근 검색어 목록 조회
+    public List<SearchKeywordResponse> getRecentSearchWords(Long userId) {
+        return searchKeywordRepository.findTop10ByUserIdOrderByModifiedDateDesc(userId).stream()
+                .map(SearchKeywordResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 내용

### SearchKeyword 엔티티 및 관련 서비스 구현:

SearchKeyword 엔티티가 추가되어, 사용자와 검색어를 연결하고 modifiedDate로 검색어의 수정 시간을 기록.
SearchKeywordService는 검색어 추가, 업데이트, 삭제 기능을 제공하며, 사용자가 최근에 검색한 상위 10개의 검색어를 조회하는 메서드 구현.

### API 구현:

검색어 추가 API: /recent-keword POST 요청을 통해 검색어를 저장. 중복된 검색어는 modifiedDate만 갱신.
검색어 조회 API: /recent-keword GET 요청을 통해 사용자의 최근 검색어 상위 10개를 제공.
검색어 삭제 API: /recent-keword DELETE 요청으로 사용자의 특정 검색어를 삭제.

SearchKeywordRepository에서 사용자의 검색어를 조회하고, 검색어의 추가 및 삭제를 처리하는 메서드가 정의됨.
이 커밋은 최근 검색어 기능을 DB 기반으로 구현하며, 사용자별로 검색어 기록을 관리하고, 검색어 조회 및 삭제 기능을 제공하는 것이 핵심입니다.