### PR TITLE
Fix(#Party-Approval-name) partyApprovalCount 네이밍 변경

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/PartyVoteDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/PartyVoteDto.java
@@ -13,13 +13,13 @@ import lombok.Getter;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PartyVoteDto {
     private PartyDto partyInfo;
-    private Integer approvalCount;
+    private Integer partyApprovalCount;
 
 
     public static PartyVoteDto from(VoteParty voteParty) {
         return PartyVoteDto.builder()
                 .partyInfo(PartyDto.from(voteParty.getParty()))
-                .approvalCount(voteParty.getVoteForCount())
+                .partyApprovalCount(voteParty.getVoteForCount())
                 .build();
     }
 


### PR DESCRIPTION
## 내용

PartyVoteDto 내부에 있는 approvalCount의 이름을 partyApprovalCount로 이름 변경