### PR TITLE
Feat(#Congressman-Party-stage) 의원, 정당이 발의한 법안 필터 적용

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/CongressmanController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/CongressmanController.java
@@ -46,7 +46,7 @@ public class CongressmanController {
     })
     @GetMapping("/detail")
     public BaseResponse<CongressmanResponse> getCongressmanDetails(
-            @Parameter(example = "04T3751T", description = "의원 Id")
+            @Parameter(example = "0PK7354M", description = "의원 Id")
             @RequestParam("congressman_id")
             String congressmanId) {
 
@@ -72,21 +72,25 @@ public class CongressmanController {
     })
     @GetMapping("/bill_info")
     public BaseResponse<BillListResponse> getCongressmanBills(
-            @Parameter(example = "04T3751T", description = "의원 Id")
+            @Parameter(example = "0PK7354M", description = "의원 Id")
             @RequestParam("congressman_id") String congressmanId,
             @Parameter(example = "represent_proposer", description = "해당 의원의 법안 대표 발의 기준, 공동 발의 기준 여부")
             @Schema(type = "String", allowableValues = {"represent_proposer", "public_proposer"})
             @RequestParam("type") String type,
+            @Parameter(example = "위원회 심사")
+            @RequestParam(value = "stage", required = false) String stage,
+            @Parameter(example = "0")
             @RequestParam("page") int page,
+            @Parameter(example = "3")
             @RequestParam("size") int size) {
 
         Pageable pageable = PageRequest.of(page, size);
 
         if (type.equals("represent_proposer")) {
-            var representativeBills = facade.getBillsFromRepresentativeProposer(congressmanId, pageable);
+            var representativeBills = facade.getBillsFromRepresentativeProposer(congressmanId, pageable, stage);
             return BaseResponse.ok(representativeBills);
         }
-        var publicProposerBills = facade.getBillsFromPublicProposer(congressmanId, pageable);
+        var publicProposerBills = facade.getBillsFromPublicProposer(congressmanId, pageable, stage);
         return BaseResponse.ok(publicProposerBills);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
@@ -68,13 +68,15 @@ public class PartyController {
                                                           @Parameter(example = "대표", description = "공동대표발의안 또는 대표발의 의안 조회 여부")
                                                           @Schema(type = "String", allowableValues = {"represent_proposer", "public_proposer"})
                                                           @RequestParam("type") String type,
+                                                          @Parameter(example = "위원회 심사")
+                                                          @RequestParam(value = "stage", required = false) String stage,
                                                           @Parameter(example = "0", description = "스크롤할 때마다 page값을 0에서 1씩 늘려주면 됩니다.")
                                                           @RequestParam(name = "page", required = true) int page,
                                                           @Parameter(example = "3", description = "한번에 가져올 데이터 크기를 의미합니다.")
                                                           @RequestParam(name = "size", required = true) int size) {
         var pageable = PageRequest.of(page, size);
-        var response = (type.equals("represent_proposer")) ? facade.getRepresentativeBillsByParty(pageable, partyId)
-                : facade.getPublicBillsByParty(pageable, partyId);
+        var response = (type.equals("represent_proposer")) ? facade.getRepresentativeBillsByParty(pageable, partyId, stage)
+                : facade.getPublicBillsByParty(pageable, partyId, stage);
 
         return BaseResponse.ok(response);
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -83,14 +83,17 @@ public class Facade {
     }
 
     // Congressman 대표 발의 가져오기
-    public BillListResponse getBillsFromRepresentativeProposer(String congressmanId, Pageable pageable) {
-        var billListResponse = billService.getBillInfoFromRepresentativeProposer(congressmanId, pageable);
+    public BillListResponse getBillsFromRepresentativeProposer(String congressmanId, Pageable pageable, String stage) {
+        var billListResponse = stage == null ? billService.getBillInfoFromRepresentativeProposer(congressmanId, pageable)
+                : billService.getBillInfoFromRepresentativeProposer(congressmanId, pageable, stage);
         return setBillListResponseBookMark(billListResponse);
     }
 
+
     // Congressman 공동 발의 법안 가져오기
-    public BillListResponse getBillsFromPublicProposer(String congressmanId, Pageable pageable) {
-        var billListResponse = billService.getBillInfoFromPublicProposer(congressmanId, pageable);
+    public BillListResponse getBillsFromPublicProposer(String congressmanId, Pageable pageable, String stage) {
+        var billListResponse = stage == null ? billService.getBillInfoFromPublicProposer(congressmanId, pageable)
+                : billService.getBillInfoFromPublicProposer(congressmanId, pageable, stage);
         return setBillListResponseBookMark(billListResponse);
     }
 
@@ -130,13 +133,15 @@ public class Facade {
     }
 
     //
-    public BillListResponse getRepresentativeBillsByParty(Pageable pageable, long partyId) {
-        var billListResponse = billService.getRepresentativeBillsByParty(pageable, partyId);
+    public BillListResponse getRepresentativeBillsByParty(Pageable pageable, long partyId, String stage) {
+        var billListResponse = stage == null ? billService.getRepresentativeBillsByParty(pageable, partyId)
+                : billService.getRepresentativeBillsByParty(pageable, partyId, stage);
         return setBillListResponseBookMark(billListResponse);
     }
 
-    public BillListResponse getPublicBillsByParty(Pageable pageable, long partyId) {
-        var billListResponse = billService.getPublicBillsByParty(pageable, partyId);
+    public BillListResponse getPublicBillsByParty(Pageable pageable, long partyId, String stage) {
+        var billListResponse = stage == null ? billService.getPublicBillsByParty(pageable, partyId)
+                : billService.getPublicBillsByParty(pageable, partyId, stage);
         return setBillListResponseBookMark(billListResponse);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -32,11 +32,23 @@ public interface BillRepository extends JpaRepository<Bill, String> {
             "ORDER BY b.proposeDate desc, b.id desc")
     Slice<Bill> findByRepresentativeProposer(String congressmanId, Pageable pageable);
 
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select rp FROM b.representativeProposer rp where rp.congressman.id = :congressmanId) " +
+            "AND b.stage = :stage " +
+            "ORDER BY b.proposeDate desc, b.id desc")
+    Slice<Bill> findByRepresentativeProposer(String congressmanId, Pageable pageable, String stage);
+
     // 특정의원이 공동 발의한 법안들
     @Query("SELECT b FROM Bill b " +
             "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.id = :congressmanId) " +
             "ORDER BY b.proposeDate desc, b.id desc")
     Slice<Bill> findBillByPublicProposer(String congressmanId, Pageable pageable);
+
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.id = :congressmanId) " +
+            "AND b.stage = :stage " +
+            "ORDER BY b.proposeDate desc, b.id desc")
+    Slice<Bill> findBillByPublicProposer(String congressmanId, Pageable pageable, String stage);
 
     // 정당 소속 의원들이 대표 발의한 법안
     @Query("SELECT b FROM Bill b " +
@@ -44,12 +56,24 @@ public interface BillRepository extends JpaRepository<Bill, String> {
             "ORDER BY b.proposeDate DESC, b.id DESC")
     Slice<Bill> findRepresentativeBillsByParty(Pageable pageable, @Param("partyId") long partyId);
 
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select rp FROM b.representativeProposer rp where rp.congressman.party.id = :partyId) " +
+            "AND b.stage = :stage " +
+            "ORDER BY b.proposeDate DESC, b.id DESC")
+    Slice<Bill> findRepresentativeBillsByParty(Pageable pageable, @Param("partyId") long partyId, String stage);
+
     // 정당 소속 의원들이 공동 발의한 법안
     // TODO: 쿼리 개선 필요
     @Query("SELECT b FROM Bill b " +
             "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.party.id = :partyId) " +
             "ORDER BY b.proposeDate DESC, b.id DESC")
     Slice<Bill> findPublicBillsByParty(Pageable pageable, @Param("partyId") long partyId);
+
+    @Query("SELECT b FROM Bill b " +
+            "WHERE exists (select bp FROM b.publicProposer bp where bp.congressman.party.id = :partyId) " +
+            "AND b.stage = :stage " +
+            "ORDER BY b.proposeDate DESC, b.id DESC")
+    Slice<Bill> findPublicBillsByParty(Pageable pageable, @Param("partyId") long partyId, String stage);
 
     // 유저가 스크랩한 법안 페이징해서 가져오는 쿼리
     @Query("SELECT b FROM Bill b " +

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -77,7 +77,10 @@ public class BillService {
     public BillListResponse getBillInfoFromRepresentativeProposer(String congressmanId, Pageable pageable) {
         var billSlice = billRepository.findByRepresentativeProposer(congressmanId, pageable);
         return getBillListResponse(billSlice, BillOrderType.BASIC);
-
+    }
+    public BillListResponse getBillInfoFromRepresentativeProposer(String congressmanId, Pageable pageable, String stage) {
+        var billSlice = billRepository.findByRepresentativeProposer(congressmanId, pageable, stage);
+        return getBillListResponse(billSlice, BillOrderType.BASIC);
     }
 
     public BillListResponse getBillInfoFromPublicProposer(String congressmanId, Pageable pageable) {
@@ -85,17 +88,28 @@ public class BillService {
         return getBillListResponse(billSlice, BillOrderType.BASIC);
 
     }
+    public BillListResponse getBillInfoFromPublicProposer(String congressmanId, Pageable pageable, String stage) {
+        var billSlice = billRepository.findBillByPublicProposer(congressmanId, pageable, stage);
+        return getBillListResponse(billSlice, BillOrderType.BASIC);
+    }
 
     public BillListResponse getRepresentativeBillsByParty(Pageable pageable, long partyId) {
         var billSlice = billRepository.findRepresentativeBillsByParty(pageable, partyId);
         return getBillListResponse(billSlice, BillOrderType.BASIC);
 
     }
+    public BillListResponse getRepresentativeBillsByParty(Pageable pageable, long partyId, String stage) {
+        var billSlice = billRepository.findRepresentativeBillsByParty(pageable, partyId, stage);
+        return getBillListResponse(billSlice, BillOrderType.BASIC);
+    }
 
     public BillListResponse getPublicBillsByParty(Pageable pageable, long partyId) {
         var billSlice = billRepository.findPublicBillsByParty(pageable, partyId);
         return getBillListResponse(billSlice, BillOrderType.BASIC);
-
+    }
+    public BillListResponse getPublicBillsByParty(Pageable pageable, long partyId, String stage) {
+        var billSlice = billRepository.findPublicBillsByParty(pageable, partyId, stage);
+        return getBillListResponse(billSlice, BillOrderType.BASIC);
     }
 
     public BillListResponse findByUserAndCongressmanLike(Pageable pageable) {


### PR DESCRIPTION
## 요약
의원 및 정당이 발의한 법안에 대해 stage필터를 적용하였습니다.

## 변경 내용

### 1. 의원 상세 법안 조회 API (/congressman/bill_info)
변경 전:
의원의 대표 발의 또는 공동 발의 법안 목록을 조회할 수 있었으나, 법안 단계에 대한 필터링은 없었습니다.

변경 후:
stage 파라미터가 추가되어, 특정 단계(예: "위원회 심사")의 법안만 조회할 수 있게 되었습니다. 사용자가 stage 값을 입력하지 않으면 모든 법안을 조회하고, 입력하면 해당 단계의 법안만 필터링해서 조회합니다.

예시:
대표 발의 법안 조회 시 stage가 있는 경우, Facade에서 stage에 맞는 법안을 필터링하여 조회합니다.

### 2. 정당별 법안 조회 API (/party/bill_info)
변경 전:
특정 정당 소속 의원들이 발의한 대표 발의 또는 공동 발의 법안만 조회할 수 있었으며, 법안 단계에 대한 필터링은 없었습니다.

변경 후:
stage 파라미터가 추가되어, 특정 단계의 법안을 필터링할 수 있게 되었습니다. stage 값이 없을 경우 기존 방식대로 모든 법안을 조회하고, 입력된 경우 해당 단계의 법안만 필터링합니다.

예시:
사용자가 특정 정당의 대표 발의 법안을 조회하면서 stage 파라미터를 함께 보내면, 해당 단계의 법안만 반환됩니다.

### 3. 법안 서비스 로직 (대표 발의 / 공동 발의)
변경 전:
- BillService는 대표 발의 또는 공동 발의 법안을 필터링 없이 모두 조회했습니다.

변경 후:
- BillService에 stage 조건이 추가되었습니다. stage가 입력되면 해당 단계의 법안만 필터링해서 반환하며, 입력되지 않으면 기존대로 모든 법안을 반환합니다.

요약
법안의 단계(stage)를 기준으로 법안을 필터링하는 기능이 추가되었습니다.
stage 파라미터를 통해, 사용자는 특정 단계의 법안만 조회할 수 있습니다.