### PR TITLE
Feat(#Party) 정당 간부 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyDetailResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyDetailResponse.java
@@ -3,6 +3,8 @@ package com.everyones.lawmaking.common.dto.response;
 import com.everyones.lawmaking.domain.entity.Party;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -36,6 +38,18 @@ public class PartyDetailResponse {
     @NotNull
     private String websiteUrl;
 
+    @Schema(name = "당대표")
+    private String partyLeader;
+
+    @Schema(name = "원내 대표")
+    private String parliamentaryLeader;
+
+    @Schema(name = "사무 총장")
+    private String secretaryGeneral;
+
+    @Schema(name = "정책위의장")
+    private String policyCommitteeChairman;
+
 
     public static PartyDetailResponse from(Party party) {
         var partyFollow = party.getPartyFollow();
@@ -49,6 +63,10 @@ public class PartyDetailResponse {
                 .totalCongressmanCount(0)
                 .representativeBillCount(party.getRepresentativeBillCount())
                 .publicBillCount(party.getPublicBillCount())
+                .partyLeader(party.getPartyLeader())
+                .parliamentaryLeader(party.getParliamentaryLeader())
+                .secretaryGeneral(party.getSecretaryGeneral())
+                .policyCommitteeChairman(party.getPolicyCommitteeChairman())
                 .followCount(partyFollow.size())
                 .isFollowed(false)
                 .build();

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Party.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.domain.entity;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -67,6 +68,22 @@ public class Party extends BaseEntity{
     @ColumnDefault("0")
     @Column(name = "is_parliamentary")
     private Boolean isParliamentary;
+
+    @Schema(name = "당대표")
+    @Column(name = "party_leader")
+    private String partyLeader;
+
+    @Schema(name = "원내 대표")
+    @Column(name = "parliamentary_leader")
+    private String parliamentaryLeader;
+
+    @Schema(name = "사무 총장")
+    @Column(name = "secretary_general")
+    private String secretaryGeneral;
+
+    @Schema(name = "정책위의장")
+    @Column(name = "policy_committee_chairman")
+    private String policyCommitteeChairman;
 
     public static Party create(String partyName ){
         return Party.builder()


### PR DESCRIPTION
## 네용

정당에 대한 세부 정보에 당 간부 정보를 추가하는 기능을 구현했습니다.

도메인(Entity) 변경: Party 엔티티에 당 대표(partyLeader), 원내 대표(parliamentaryLeader), 사무 총장(secretaryGeneral), 정책위 의장(policyCommitteeChairman) 필드를 새로 추가했습니다. 이 필드는 각각 @Column과 @Schema 어노테이션으로 정의되어 있으며, 데이터베이스 컬럼에 매핑됩니다.
DTO 변경: PartyDetailResponse DTO에도 위와 동일한 필드가 추가되었습니다. 이로 인해 API 응답에 새로운 정당 간부 정보가 포함될 수 있습니다.
변환 로직 수정: PartyDetailResponse.from(Party) 메서드를 수정하여 Party 엔티티에서 추가된 간부 정보를 DTO로 변환하도록 했습니다.