### PR TITLE
Feat(#Social_jdbc_authentication-Withdrawal) 소셜 계정 탈퇴 및 데이터 정리 기능 구현

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/KakaoAccessTokenRefreshResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/KakaoAccessTokenRefreshResponse.java
@@ -1,0 +1,21 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class KakaoAccessTokenRefreshResponse {
+    private String accessToken;
+    private String tokenType;
+    private Integer expiresIn;
+    private String refreshToken;
+    private Integer refreshTokenExpiresIn;
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/AuthController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/AuthController.java
@@ -14,8 +14,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_CONTENT;
 
@@ -45,9 +47,8 @@ public class AuthController {
             Authentication authentication,
             HttpServletRequest request,
             HttpServletResponse response) throws Exception {
-        var userDetails = (UserDetails) authentication.getPrincipal();
 
-        var result = facade.withdraw(userDetails.getUsername(),request,response);
+        var result = facade.withdraw(request,response);
         return BaseResponse.ok(result);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/AuthInfo.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/AuthInfo.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -13,7 +11,6 @@ import org.hibernate.annotations.OnDeleteAction;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@OnDelete(action = OnDeleteAction.CASCADE)
 public class AuthInfo extends BaseEntity {
 
     @Id

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/SocialToken.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/SocialToken.java
@@ -1,0 +1,52 @@
+package com.everyones.lawmaking.domain.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SocialToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String clientRegistrationId;
+    private String principalName;
+    private String accessToken;
+    private Instant accessTokenIssuedAt;
+    private Instant accessTokenExpiresAt;
+    private String refreshToken;
+    private Instant refreshTokenIssuedAt;
+
+    public static SocialToken from(OAuth2AuthorizedClient authorizedClient, Authentication principal){
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+        return SocialToken.builder().accessToken(accessToken.getTokenValue())
+                .accessTokenExpiresAt(Objects.requireNonNull(accessToken.getExpiresAt()))
+                .accessTokenIssuedAt(Objects.requireNonNull(accessToken.getIssuedAt()))
+                .clientRegistrationId(authorizedClient.getClientRegistration().getRegistrationId())
+                .principalName(principal.getName())
+                .refreshToken(Objects.requireNonNull(refreshToken).getTokenValue())
+                .refreshTokenIssuedAt(Objects.requireNonNull(refreshToken.getIssuedAt()))
+                .build();
+
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Token.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Token.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -13,7 +11,6 @@ import org.hibernate.annotations.OnDeleteAction;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@OnDelete(action = OnDeleteAction.CASCADE)
 public class Token extends BaseEntity {
 
     @Id

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/User.java
@@ -4,8 +4,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
 
@@ -16,7 +14,6 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@OnDelete(action = OnDeleteAction.CASCADE)
 public class User extends BaseEntity {
 
     @Id

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -386,7 +386,13 @@ public class Facade {
                 // 모든 작업이 성공적으로 완료되었을 때만 WithdrawResponse 반환
                 return WithdrawResponse.of(authInfo);
 
-            } catch (HttpClientErrorException | HttpServerErrorException e) {
+            }
+            catch (AuthException | UserException e) {
+                // 인증 정보 삭제 실패 시 롤백 설정
+                status.setRollbackOnly();
+                throw e;
+            }
+            catch (HttpClientErrorException | HttpServerErrorException e) {
                 // 외부 API 호출 실패 시 롤백 설정
                 status.setRollbackOnly();
                 String kakaoErrorMessage = e.getResponseBodyAsString();
@@ -402,7 +408,7 @@ public class Facade {
             }
         });
     }
-    public void deleteUserAccount(Long userId, String socialId) throws RuntimeException {
+    public void deleteUserAccount(Long userId, String socialId) {
         try{
 
 
@@ -430,7 +436,7 @@ public class Facade {
         catch (Exception e) {
             log.error("Error during user account deletion", e);
 
-            throw new UserException.UserDeleteFailureException(Map.of("userId", String.valueOf(userId)));
+            throw e;
         }
 
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/AppProperties.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/AppProperties.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -18,11 +17,18 @@ public class AppProperties {
 
     @Getter
     @Setter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Auth {
         @Value("${app.auth.token-secret}")
         private  String tokenSecret;
+
+        @Value("${app.auth.kakao-app-client-id}")
+        private  String kakaoAppClientId;
+
+        @Value("${app.auth.kakao-app-client-secret}")
+        private String kakaoAppClientSecret;
 
         @Value("${app.auth.access-token-expiry}")
         private  long accessTokenExpiry;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -3,9 +3,11 @@ package com.everyones.lawmaking.global.config;
 import com.everyones.lawmaking.global.filterException.CustomAuthenticationEntryPoint;
 import com.everyones.lawmaking.global.handler.*;
 import com.everyones.lawmaking.global.jwt.AuthTokenProvider;
+import com.everyones.lawmaking.global.service.CustomOAuth2AuthorizedClientService;
 import com.everyones.lawmaking.global.service.CustomOAuth2UserService;
 import com.everyones.lawmaking.global.service.TokenService;
 import com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.everyones.lawmaking.repository.OAuth2ClientTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +15,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
@@ -35,6 +39,8 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer Ïù
     private final AuthTokenProvider tokenProvider;
     private final CustomOAuth2UserService oAuth2UserService;
     private final TokenAccessDeniedHandler tokenAccessDeniedHandler;
+    private final OAuth2ClientTokenRepository oAuth2ClientTokenRepository;
+    private final ClientRegistrationRepository clientRegistrationRepository;
     private final CorsConfig corsConfig;
     private final TokenService tokenService;
 
@@ -73,6 +79,7 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer Ïù
                         .successHandler(oAuth2AuthenticationSuccessHandler())
                         .failureHandler(oAuth2AuthenticationFailureHandler()
                         )
+                        .authorizedClientService(customOAuth2AuthorizedClientService())
                 )
                 .logout((logOut) ->
                         logOut
@@ -135,12 +142,13 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer Ïù
      * */
     @Bean
     public OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler() {
-        return new OAuth2AuthenticationFailureHandler(oAuth2AuthorizationRequestBasedOnCookieRepository());
+        return new OAuth2AuthenticationFailureHandler(oAuth2AuthorizationRequestBasedOnCookieRepository(), oAuth2ClientTokenRepository);
     }
 
-    /*
-     * Cors ÏÑ§Ï†ï
-     * */
+    @Bean
+    public OAuth2AuthorizedClientService customOAuth2AuthorizedClientService() {
+        return new CustomOAuth2AuthorizedClientService(oAuth2ClientTokenRepository, clientRegistrationRepository);
+    }
 
 }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TransactionTemplateConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TransactionTemplateConfig.java
@@ -1,0 +1,16 @@
+package com.everyones.lawmaking.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionTemplateConfig {
+    @Bean
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(false);
+        return transactionTemplate;
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ErrorCode.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ErrorCode.java
@@ -33,6 +33,11 @@ public enum ErrorCode {
 
     NOTIFICATION_NOT_FOUND(404, "해당 알림을 찾을 수 없습니다."),
 
+    SOCIAL_TOKEN_NOT_FOUND(404, "해당 소셜 토큰을 찾을 수 없습니다."),
+    EXTERNAL_API_ERROR(502, "외부 API 호출 중 오류가 발생하였습니다."),
+    WITHDRAWAL_FAILURE(409, "해당 유저의 탈퇴가 실패하였습니다."),
+    USER_DELETE_FAILURE(500, "해당 유저의 삭제가 실패하였습니다."),
+
     // 업데이트를 위해 제공된 파라미터와 DB 내부 값이 일치하여 반환해주는 에러
     BAD_UPDATE_PARAMETER(400, "업데이트 하려는 파라미터와 DB 내부 값이 일치합니다."),
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ExternalException.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/ExternalException.java
@@ -1,0 +1,22 @@
+package com.everyones.lawmaking.global.error;
+
+import java.util.Map;
+
+public class ExternalException extends CustomException {
+    public ExternalException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public ExternalException(ErrorCode errorCode, Map<String, String> inputValuesByProperty) {
+        super(errorCode, inputValuesByProperty);
+    }
+
+    public static class ApiException extends ExternalException {
+        public ApiException(ErrorCode errorCode) {
+            super(errorCode);
+        }
+
+        public ApiException(ErrorCode errorCode, Map<String, String> parameters) {
+            super(errorCode, parameters);
+        }
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/SocialTokenException.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/SocialTokenException.java
@@ -1,0 +1,24 @@
+package com.everyones.lawmaking.global.error;
+
+import java.util.Map;
+
+public class SocialTokenException extends CustomException {
+    public SocialTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public SocialTokenException(ErrorCode errorCode, Map<String, String> inputValueProperties) {
+        super(errorCode, inputValueProperties);
+    }
+
+    public static class SocialTokenNotFound extends NotificationException {
+
+        public SocialTokenNotFound() {
+            super(ErrorCode.SOCIAL_TOKEN_NOT_FOUND);
+        }
+
+        public SocialTokenNotFound(Map<String, String> inputValueProperties) {
+            super(ErrorCode.SOCIAL_TOKEN_NOT_FOUND, inputValueProperties);
+        }
+
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/error/UserException.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/error/UserException.java
@@ -21,5 +21,25 @@ public class UserException extends CustomException {
         }
     }
 
+    public static class WithdrawalFailureException extends UserException {
+        public WithdrawalFailureException() {
+            super(ErrorCode.WITHDRAWAL_FAILURE);
+        }
+
+        public WithdrawalFailureException(Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.WITHDRAWAL_FAILURE, inputValuesByProperty);
+        }
+    }
+
+    public static class UserDeleteFailureException extends UserException {
+        public UserDeleteFailureException() {
+            super(ErrorCode.USER_DELETE_FAILURE);
+        }
+
+        public UserDeleteFailureException(Map<String, String> inputValuesByProperty) {
+            super(ErrorCode.USER_DELETE_FAILURE, inputValuesByProperty);
+        }
+    }
+
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/OAuth2AuthenticationFailureHandler.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/handler/OAuth2AuthenticationFailureHandler.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.global.handler;
 
 import com.everyones.lawmaking.global.util.CookieUtil;
 import com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.everyones.lawmaking.repository.OAuth2ClientTokenRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +22,7 @@ import static com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBased
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     private final OAuth2AuthorizationRequestBasedOnCookieRepository authorizationRequestRepository;
+    private final OAuth2ClientTokenRepository oAuth2ClientTokenRepository;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws ServletException, IOException {
@@ -31,6 +33,12 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                 .queryParam("error", exception.getLocalizedMessage())
                 .build().toUriString();
 
+        // 사용자 principal (사용자명 등)을 가져와서 토큰 삭제
+        String clientRegistrationId = request.getParameter("client_id"); // 예: google, facebook 등
+        if (clientRegistrationId != null && request.getUserPrincipal() != null) {
+            String principalName = request.getUserPrincipal().getName();
+            oAuth2ClientTokenRepository.deleteByClientRegistrationIdAndPrincipalName(clientRegistrationId, principalName);
+        }
         authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/service/CustomOAuth2AuthorizedClientService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/service/CustomOAuth2AuthorizedClientService.java
@@ -1,0 +1,64 @@
+package com.everyones.lawmaking.global.service;
+
+import com.everyones.lawmaking.domain.entity.SocialToken;
+import com.everyones.lawmaking.repository.OAuth2ClientTokenRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+
+import java.util.Optional;
+
+public class CustomOAuth2AuthorizedClientService implements OAuth2AuthorizedClientService {
+    private final OAuth2ClientTokenRepository clientTokenRepository; // OAuth2 클라이언트 정보 저장소 (데이터베이스 연동용)
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+
+    public CustomOAuth2AuthorizedClientService(OAuth2ClientTokenRepository clientTokenRepository,
+                                               ClientRegistrationRepository clientRegistrationRepository) {
+        this.clientTokenRepository = clientTokenRepository;
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId, String principalName) {
+        Optional<SocialToken> clientEntity = clientTokenRepository.findTop1ByClientRegistrationIdAndPrincipalNameOrderByCreatedDateDesc(clientRegistrationId, principalName);
+
+        if (clientEntity.isPresent()) {
+            SocialToken socialToken = clientEntity.get();
+            ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(clientRegistrationId);
+            OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                    OAuth2AccessToken.TokenType.BEARER,
+                    socialToken.getAccessToken(),
+                    socialToken.getAccessTokenIssuedAt(),
+                    socialToken.getAccessTokenExpiresAt()
+            );
+            OAuth2RefreshToken refreshToken = new OAuth2RefreshToken(
+                    socialToken.getRefreshToken(),
+                    socialToken.getRefreshTokenIssuedAt()
+            );
+
+            return (T) new OAuth2AuthorizedClient(registration, principalName, accessToken, refreshToken);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
+
+        SocialToken clientEntity = SocialToken.from(authorizedClient, principal);
+
+        clientTokenRepository.save(clientEntity); // 데이터베이스에 저장
+    }
+
+    @Override
+    public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
+        clientTokenRepository.deleteByClientRegistrationIdAndPrincipalName(clientRegistrationId, principalName);
+    }
+}
+

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/AuthenticationUtil.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/AuthenticationUtil.java
@@ -1,8 +1,10 @@
 package com.everyones.lawmaking.global.util;
 
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public class AuthenticationUtil {
@@ -13,5 +15,18 @@ public class AuthenticationUtil {
             return Optional.empty();
         }
             return Optional.of(Long.parseLong(userDetails.getUsername()));
+    }
+
+    private static boolean hasAuthority(Collection<? extends GrantedAuthority> authorities, String authority) {
+        if (authorities == null) {
+            return false;
+        }
+
+        for (GrantedAuthority grantedAuthority : authorities) {
+            if (authority.equals(grantedAuthority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/AuthInfoRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/AuthInfoRepository.java
@@ -4,6 +4,7 @@ import com.everyones.lawmaking.domain.entity.AuthInfo;
 import com.everyones.lawmaking.domain.entity.Provider;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,9 @@ public interface AuthInfoRepository extends JpaRepository<AuthInfo, Long> {
             "from AuthInfo a " +
             "inner join fetch a.user u " +
             "where u.id =:userId ")
-    Optional<AuthInfo> findAuthInfoByUserId(@Param("userId") String userId);
+    Optional<AuthInfo> findAuthInfoByUserId(@Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true)
+    int deleteBySocialId(@Param("userId") String socialId);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillLikeRepository.java
@@ -2,11 +2,11 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.BillLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,6 +19,9 @@ public interface BillLikeRepository extends JpaRepository<BillLike, Long > {
     Long countByUserId(long userId);
 
 //    void deleteById(@Param("billLikeId") long billLikeId);
+
+    @Modifying(clearAutomatically = true)
+    void deleteAllByUserId(Long userId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanLikeRepository.java
@@ -2,11 +2,11 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.CongressmanLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -20,6 +20,9 @@ public interface CongressmanLikeRepository extends JpaRepository<CongressmanLike
     Long countByUserId(long userId);
 
     Long countByCongressmanId(String congressmanId);
+
+    @Modifying(clearAutomatically = true)
+    void deleteByUserId(Long userId);
 
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -62,6 +63,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             where u.id = :userId and n.isRead = false
             """)
     Integer countNewNotificationsByUserId(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    void deleteAllByUserId(Long userId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -29,9 +29,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository implements Author
     @Override
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
         if (authorizationRequest == null) {
-            CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-            CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+            removeAuthorizationRequestCookies(request, response);
             return;
         }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2ClientTokenRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/OAuth2ClientTokenRepository.java
@@ -1,0 +1,14 @@
+package com.everyones.lawmaking.repository;
+
+import com.everyones.lawmaking.domain.entity.SocialToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OAuth2ClientTokenRepository extends JpaRepository<SocialToken, Long> {
+    Optional<SocialToken> findTop1ByClientRegistrationIdAndPrincipalNameOrderByCreatedDateDesc(String clientRegistrationId,String principalName);
+    void deleteByClientRegistrationIdAndPrincipalName(String clientRegistrationId, String principalName);
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyFollowRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/PartyFollowRepository.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.PartyFollow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,7 @@ public interface PartyFollowRepository extends JpaRepository<PartyFollow, Long> 
     @Query("select pf from PartyFollow pf " +
             "where pf.party.id = :partyId AND pf.user.id = :userId ")
     Optional<PartyFollow> findByUserIdAndPartyId(@Param("userId") long userId, @Param("partyId") long partyId);
+
+    @Modifying(clearAutomatically = true)
+    void deleteAllByUserId(Long userId);
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/SearchKeywordRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/SearchKeywordRepository.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.SearchKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,6 +17,9 @@ public interface SearchKeywordRepository extends JpaRepository<SearchKeyword, Lo
     Optional<SearchKeyword> findByUserIdAndSearchWord(Long userId, String searchWord);
 
     void deleteByUserIdAndSearchWord(Long userId, String searchWord);
+
+    @Modifying(clearAutomatically = true)
+    void deleteAllByUserId(Long userId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/TokenRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/TokenRepository.java
@@ -2,8 +2,10 @@ package com.everyones.lawmaking.repository;
 
 import com.everyones.lawmaking.domain.entity.Token;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -16,6 +18,10 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
             "inner join fetch t.user u " +
             "where t.refreshToken =:refreshToken ")
     Optional<Token> findTokenByRefreshToken(@Param("refreshToken") String refreshToken);
+
+    @Transactional(rollbackFor = Exception.class)
+    @Modifying(clearAutomatically = true)
+    Integer deleteByUserId(Long userId);
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/TokenRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/TokenRepository.java
@@ -19,7 +19,6 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
             "where t.refreshToken =:refreshToken ")
     Optional<Token> findTokenByRefreshToken(@Param("refreshToken") String refreshToken);
 
-    @Transactional(rollbackFor = Exception.class)
     @Modifying(clearAutomatically = true)
     Integer deleteByUserId(Long userId);
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.everyones.lawmaking.repository;
 import com.everyones.lawmaking.domain.entity.Provider;
 import com.everyones.lawmaking.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -34,4 +35,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "where bl.bill.id = :billId")
     List<User> findAllByBillId(@Param("billId") String billId);
 
+    @Modifying(clearAutomatically = true)
+    int deleteUserById(Long userId);
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/AuthService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/AuthService.java
@@ -1,8 +1,7 @@
 package com.everyones.lawmaking.service;
 
-import com.everyones.lawmaking.common.dto.response.WithdrawResponse;
+import com.everyones.lawmaking.domain.entity.AuthInfo;
 import com.everyones.lawmaking.global.config.AppProperties;
-import com.everyones.lawmaking.global.config.RestTemplateConfig;
 import com.everyones.lawmaking.global.error.AuthException;
 import com.everyones.lawmaking.global.service.TokenService;
 import com.everyones.lawmaking.global.util.CookieUtil;
@@ -12,13 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
 
 import java.util.Map;
 
@@ -32,45 +26,10 @@ import static com.everyones.lawmaking.repository.OAuth2AuthorizationRequestBased
 public class AuthService {
 
     private final AuthInfoRepository authInfoRepository;
-    private final RestTemplateConfig restTemplateUtil;
     private final AppProperties appProperties;
     private final TokenService tokenService;
     private static final String TARGET_ID_TYPE = "user_id";
 
-    @Transactional
-    public WithdrawResponse withdraw(String userId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
-        var authInfoSaved = authInfoRepository.findAuthInfoByUserId(userId)
-                .orElseThrow(() -> new AuthException.AuthInfoNotFound(Map.of("userId", userId)));
-
-
-
-        try {
-            // 카카오 서버에 회원탈퇴 포스트 날림
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("Authorization","KakaoAK " + appProperties.getAuth().getKakaoAppAdminKey());
-
-            LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            params.add("target_id_type", TARGET_ID_TYPE);
-            params.add("target_id", authInfoSaved.getSocialId());
-
-            HttpEntity<MultiValueMap<String, String>> kakaoWithdrawRequest = new HttpEntity<>(params, headers);
-            String url = appProperties.getAuth().getKakaoWithdrawUri();
-
-            restTemplateUtil.restTemplate().postForEntity(url, kakaoWithdrawRequest, String.class);
-
-        } catch (RestClientException e) {
-            log.error("카카오 계정 연결 해제 중 오류가 발생하였습니다.", e);
-            throw new AuthException.ThirdPartyError();
-        }
-
-        // userId기반으로 authInfo 가져와서 일괄 삭제
-        authInfoRepository.delete(authInfoSaved);
-
-        // 로그아웃
-        tokenService.logout(httpServletRequest,httpServletResponse);
-
-        return WithdrawResponse.of(authInfoSaved);
-    }
 
     @Transactional
     public void reissueToken(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
@@ -129,5 +88,13 @@ public class AuthService {
         }
         return null;
     }
-
+    public AuthInfo getAuthInfo(Long userId) {
+        return authInfoRepository.findAuthInfoByUserId(userId)
+                .orElseThrow(() -> new AuthException.AuthInfoNotFound(Map.of("userId", String.valueOf(userId))));
     }
+
+    public  int deleteAuthInfoBySocialId(String socialId) {
+        return authInfoRepository.deleteBySocialId(socialId);
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/LikeService.java
@@ -141,4 +141,17 @@ public class LikeService {
         return congressmanLikeRepository.countByCongressmanId(congressmanId).intValue();
     }
 
+    public void deleteCongressmanLikeByUserId(Long userId) {
+        congressmanLikeRepository.deleteByUserId(userId);
+    }
+
+    public void deleteBillLikeByUserId(Long userId) {
+        billLikeRepository.deleteAllByUserId(userId);
+    }
+
+    public void deletePartyFollowByUserId(Long userId) {
+        partyFollowRepository.deleteAllByUserId(userId);
+    }
+
+
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -64,6 +64,10 @@ public class NotificationService {
         return "success";
     }
 
+    public void deleteNotificationByUserId(Long userId){
+        notificationRepository.deleteAllByUserId(userId);
+    }
+
     public NotificationCountResponse countNotifications(long userId){
         Integer notification = notificationRepository.countNewNotificationsByUserId(userId);
         return NotificationCountResponse.of(userId, notification);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/OAuthService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/OAuthService.java
@@ -1,0 +1,93 @@
+package com.everyones.lawmaking.service;
+
+
+import com.everyones.lawmaking.common.dto.response.KakaoAccessTokenRefreshResponse;
+import com.everyones.lawmaking.global.config.AppProperties;
+import com.everyones.lawmaking.global.error.SocialTokenException;
+import com.everyones.lawmaking.repository.OAuth2ClientTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class OAuthService {
+
+    private final AppProperties appProperties;
+    private final OAuth2ClientTokenRepository oAuth2ClientTokenRepository;
+    private static final String PRINCIPAL_NAME_STRING = "socialTokenPrincipalName";
+
+    private final RestTemplate restTemplate;
+
+
+
+    //소셜 엑세스토큰 재발급 로직
+    // 데이터베이스에 저장된 소셜 리프레시토큰을 활용해 엑세스토큰 발급
+    public ResponseEntity<KakaoAccessTokenRefreshResponse> refreshAccessToken(String clientRegistrationId, String socialId){
+        var auth = appProperties.getAuth();
+        var refreshToken = oAuth2ClientTokenRepository.findTop1ByClientRegistrationIdAndPrincipalNameOrderByCreatedDateDesc(clientRegistrationId, socialId)
+                .orElseThrow(() -> new SocialTokenException.SocialTokenNotFound(Map.of(PRINCIPAL_NAME_STRING, socialId)))
+                .getRefreshToken();
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+        // MultiValueMap으로 요청 데이터 설정
+        MultiValueMap<String, String> requestData = new LinkedMultiValueMap<>();
+        requestData.add("grant_type", "refresh_token");
+        requestData.add("client_id", auth.getKakaoAppClientId());
+        requestData.add("client_secret", auth.getKakaoAppClientSecret());
+        requestData.add("refresh_token", refreshToken);
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HttpEntity 생성
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestData, headers);
+        var kakaoAccessTokenRefreshResponse = restTemplate.postForEntity(uri, requestEntity, KakaoAccessTokenRefreshResponse.class);
+        return ResponseEntity.ok(kakaoAccessTokenRefreshResponse.getBody());
+
+    }
+
+    //소셜 연결 끊기
+    public String unlink(String socialId, String accessToken){
+        // MultiValueMap으로 요청 데이터 설정
+        MultiValueMap<String, String> requestData = new LinkedMultiValueMap<>();
+        requestData.add("target_id_type", "user_id");
+        requestData.add("target_id", socialId);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v1/user/unlink")
+                .encode()
+                .build()
+                .toUri();
+
+        RestTemplate restTemplate = new RestTemplate();
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestData, headers);
+            return restTemplate.postForEntity(uri, requestEntity, String.class).getBody();
+
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/PartyService.java
@@ -1,7 +1,10 @@
 package com.everyones.lawmaking.service;
 
 import com.everyones.lawmaking.common.dto.SearchPartyDto;
-import com.everyones.lawmaking.common.dto.response.*;
+import com.everyones.lawmaking.common.dto.response.FollowingPartyResponse;
+import com.everyones.lawmaking.common.dto.response.ParliamentaryPartyResponse;
+import com.everyones.lawmaking.common.dto.response.PartyDetailResponse;
+import com.everyones.lawmaking.common.dto.response.SearchResponse;
 import com.everyones.lawmaking.domain.entity.Party;
 import com.everyones.lawmaking.global.error.PartyException;
 import com.everyones.lawmaking.repository.PartyRepository;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/SearchKeywordService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/SearchKeywordService.java
@@ -53,4 +53,7 @@ public class SearchKeywordService {
                 .map(SearchKeywordResponse::from)
                 .toList();
     }
+    public void deleteAllSearchWordsByUserId(Long userId) {
+        searchKeywordRepository.deleteAllByUserId(userId);
+    }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/UserService.java
@@ -35,4 +35,8 @@ public class UserService {
         return userRepository.findAllByCongressmanId(congressmanId);
     }
 
+    public int deleteUserById(Long userId) {
+        return userRepository.deleteUserById(userId);
+    }
+
 }

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -50,6 +50,8 @@ server.forward-headers-strategy=FRAMEWORK
 #Kakao Config
 app.auth.kakao-app-admin-key = ${APP_ADMIN_KEY}
 app.auth.kakao-withdraw-uri = https://kapi.kakao.com/v1/user/unlink
+app.auth.kakao-app-client-id=${KAKAO_CLIENT_ID}
+app.auth.kakao-app-client-secret=${KAKAO_CLIENT_SECRET}
 
 spring.security.oauth2.client.registration.kakao.client-id = ${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret = ${KAKAO_CLIENT_SECRET}


### PR DESCRIPTION
## 내용
### 요약
이 PR은 소셜 계정을 연동한 사용자의 탈퇴 프로세스를 구현하여, 토큰 기반 로그아웃, 계정 연동 해제, 데이터베이스 정리 등의 작업을 수행합니다.
주요 변경사항으로는 소셜 토큰 기반의 인증 방식, 프로그래밍적인 트랜잭션관리, 회원탈퇴에 관한 예외사항이 있습니다.

### 변경사항
KakaoAccessTokenRefreshResponse DTO 추가: Kakao 토큰 갱신 응답을 처리하는 DTO 클래스 추가.

AuthController: withdraw 메서드를 facade로 이전, AuthInfo조회 메서드 추가

SocialToken 엔터티 추가: OAuth 토큰 정보를 데이터베이스에 저장하여 토큰 갱신 및 계정 해제 작업을 수행할 수 있도록 지원.

OAuth 서비스 (OAuthService): Kakao API를 통한 소셜 토큰 갱신 및 계정 연동 해제를 관리하는 서비스 추가.

트랜잭션 관리: 프로그래밍적 트랜잭션관리로 명시적인 트랜잭션 관리함.
회원탈퇴 관련 커스텀 예외 처리 추가: 외부 API 호출에 대한 특정 오류 처리를 위한 ExternalException 및 SocialTokenException, UserException 추가.
리포지토리 업데이트: AuthInfoRepository, TokenRepository 등에서 userId를 기반으로 삭제 기능을 지원하도록 개선.
기타 변경사항
앱 속성 업데이트: Kakao API 관련 비밀 키 구성을 추가.
에러 코드 확장: ErrorCode에 새로운 항목을 추가하여 다양한 탈퇴 실패 시나리오 지원.
@Modifying 애너테이션: 사용자 정리 중 대량 삭제 작업의 효율성을 위해 리포지토리에 @Modifying 애너테이션 적용.
영향
이번 변경으로 계정 탈퇴 시 사용자 데이터가 삭제되고, 외부 API 상호작용 시 오류 처리 기능이 향상됩니다. 시스템의 다른 부분에는 영향을 주지 않습니다.