### PR TITLE
Feat(#Logout-Authentication-Filter) 사용자 로그아웃 및 데이터 일관성 개선

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -363,9 +363,12 @@ public class Facade {
 
 
     public WithdrawResponse withdraw(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
-        var userId = AuthenticationUtil.getUserId()
-                .orElseThrow(UserException.UserNotFoundException::new);
-        var authInfo = authService.getAuthInfo(userId);
+        var userId = AuthenticationUtil.getUserId();
+        if (userId.isEmpty()) {
+            throw new UserException.UserNotFoundException();
+        }
+        var userIdValue = userId.get();
+        var authInfo = authService.getAuthInfo(userIdValue);
         var socialId = authInfo.getSocialId();
         var provider = authInfo.getProvider().name();
 
@@ -375,7 +378,7 @@ public class Facade {
                 tokenService.logout(httpRequest, httpResponse);
 
                 // 2. 데이터 삭제
-                deleteUserAccount(userId, socialId);
+                deleteUserAccount(userIdValue, socialId);
 
                 // 3. 외부 API 호출 - unlink
                 var oauthRefreshAccessTokenResponse = oAuthService.refreshAccessToken(provider, socialId);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -363,12 +363,10 @@ public class Facade {
 
 
     public WithdrawResponse withdraw(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
-        var userId = AuthenticationUtil.getUserId();
-        if (userId.isEmpty()) {
-            throw new UserException.UserNotFoundException();
-        }
-        var userIdValue = userId.get();
-        var authInfo = authService.getAuthInfo(userIdValue);
+        var userId = AuthenticationUtil.getUserId()
+                .orElseThrow(UserException.UserNotFoundException::new);
+
+        var authInfo = authService.getAuthInfo(userId);
         var socialId = authInfo.getSocialId();
         var provider = authInfo.getProvider().name();
 
@@ -378,7 +376,7 @@ public class Facade {
                 tokenService.logout(httpRequest, httpResponse);
 
                 // 2. 데이터 삭제
-                deleteUserAccount(userIdValue, socialId);
+                deleteUserAccount(userId, socialId);
 
                 // 3. 외부 API 호출 - unlink
                 var oauthRefreshAccessTokenResponse = oAuthService.refreshAccessToken(provider, socialId);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/SecurityConfig.java
@@ -49,7 +49,9 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer Ïù
     @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(customLogoutFilter(), LogoutFilter.class)
+                .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(customLogoutFilter(), tokenAuthenticationFilter().getClass())
+                .addFilterBefore(tokenAuthenticationFilter(), LogoutFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
@@ -86,10 +88,6 @@ public class SecurityConfig implements WebMvcConfigurer { // WebMvcConfigurer Ïù
                         .logoutSuccessHandler(new CustomLogoutSuccessHandler())
 
                 );
-
-
-        http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-
 
         return http.build();
     }


### PR DESCRIPTION
## 내용
로그아웃 시, Authentication객체에서 null이 발생하여 로그아웃이 불가능한 이슈를 발견하여 해결합니다.

### 변경사항 요약
Facade 클래스: withdraw 메소드의 userId 처리 방식을 개선하여, Optional 객체가 비어 있을 경우 예외를 던지도록 변경했습니다. 

authService.getAuthInfo 호출 시 안전한 userId 값을 사용하도록 수정했습니다.

SecurityConfig 클래스: 필터 체인의 순서를 재구성하여 tokenAuthenticationFilter가 customLogoutFilter 앞에 추가되도록 조정했습니다.

TokenService 클래스:
invalidateToken 및 logout 메소드에 트랜잭션을 적용하여 데이터 일관성을 강화했습니다.
logout 메소드에서 userId가 존재하는 경우에만 invalidateToken을 호출하도록 수정하여 불필요한 예외 발생을 방지했습니다.
deleteByUserId 메소드를 새로 추가하여 userId로 토큰을 삭제하는 기능을 별도로 분리했습니다.

### 관련 이슈
해당 변경 사항은 사용자 계정 로그아웃 처리 및 데이터 일관성 문제를 개선하기 위한 작업입니다.