### PR TITLE
Feat(#CommonFacade) Facade와 Service 중간 매개체 CommonFacade 생성

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/CommonFacade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/CommonFacade.java
@@ -1,0 +1,18 @@
+package com.everyones.lawmaking.facade;
+
+import com.everyones.lawmaking.service.DataService;
+import com.everyones.lawmaking.service.LikeService;
+import com.everyones.lawmaking.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommonFacade {
+    private final NotificationService notificationService;
+    private final DataService dataService;
+    private final LikeService likeService;
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TransactionConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TransactionConfig.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
-public class TransactionTemplateConfig {
+public class TransactionConfig {
     @Bean
     public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
         TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);


### PR DESCRIPTION
## 내용
리팩토링을 위해서 Facade계층을 엔티티별 Facade로 나누는 과정에서
엔티티 구분없이 의존성이 중복인 서비스 클래스를 관리하기 위한 commonFacade 클래스를 추가함

추가적으로 TransactionTemplateConfig 이름수정