### PR TITLE
Feat(#Notification) 알림 데이터 생성 날짜 타입 변경

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/NotificationResponse.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -41,7 +41,7 @@ public class NotificationResponse {
     private String type;
 
     @NotNull
-    private LocalDateTime createdDate;
+    private LocalDate createdDate;
 
     // notifications 리스트를 NotificationResponse 리스트로 만들어주는 메서드
     public static List<NotificationResponse> from(List<Notification> notifications) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -51,18 +51,13 @@ public class NotificationConverter {
         List<String> notificationImageUrlList = new ArrayList<>();
         switch (columnEventType) {
             case RP_INSERT:
-                //의원 발의
-//           billId, congressmanName, billBriefSummary, congressmanInfo
+
                 title = data.get(1) + " 의원";
                 content = "'"+data.get(2) + "' 법안을 대표 발의했어요!";
                 notificationImageUrlList.add(data.get(3));
                 break;
             case BILL_STAGE_UPDATE:
-                //의원 발의
-//              billId, briefSummary, stage, proposerKind.name()), partyInfoList.stream();
 
-                //위원장 발의
-//                billId, briefSummary, stage, proposerKind.name(),proposers
                 title = data.get(1);
                 content = "심사 단계가 '" + data.get(2) + "'로 변동했어요!";
                 extra = data.get(3);
@@ -73,10 +68,7 @@ public class NotificationConverter {
                 }
                 break;
             case BILL_RESULT_UPDATE:
-                //의원 발의
-//              billId, briefSummary, billResult, proposerKind.name()), partyInfoList.stream()
-                //위원장 발의
-//                billId, briefSummary, billResult, proposerKind.name(), proposers
+
                 title = data.get(1);
                 content = "'"+data.get(2) + "'로 처리되었어요!";
                 extra = data.get(3);
@@ -87,7 +79,6 @@ public class NotificationConverter {
                 }
                 break;
             case CONGRESSMAN_PARTY_UPDATE:
-                //congressmanId, partyName, congressmanName,congressmanInfo
                 title = data.get(2);
                 content = "'"+data.get(2)+"'의원의 당적이 '"+data.get(1)+"' 정당으로 변동했어요!";
                 notificationImageUrlList.add(data.get(3));
@@ -112,7 +103,7 @@ public class NotificationConverter {
                 .notificationImageUrlList(notificationImageUrlList)
                 .title(title)
                 .content(content)
-                .createdDate(createdDate)
+                .createdDate(createdDate.toLocalDate())
                 .extra(extra)
                 .build();
     }


### PR DESCRIPTION
## 내용
![image](https://github.com/user-attachments/assets/6e5efa4b-5188-4bc1-9b82-2af75a05ddd5)
위와 같이 알림 조회 페이지에서 알림 생성 데이터에서 T이하인 시간부분을 떼는 작업을 하였습니다.

데이터는 LocalDateTime으로 생성을 하기에 우선 생성된 데이터가 잘못 들어간 데이터인지 유효성 검사를 해주고
LocalDateTime의 toLocalDate() 메서드를 통하여 LocalDate로 변환하여 NotificationResponse에 넣어주었습니다.