### PR TITLE
Feat(#Data-Automation-API) 법안 정보 삽입 시, party정보 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/DataService.java
@@ -56,7 +56,7 @@ public class DataService {
                             .forEach(congressmanId -> {
                                 var billProposer = congressmanRepository.findLawmakerById(congressmanId)
                                         .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", congressmanId)));
-                                        billProposerUpdate(newBill, billProposer);
+                                billProposerUpdate(newBill, billProposer);
                                     }
                             );
                     //대표발의자 이름 검색해서 RP 찾기
@@ -64,7 +64,7 @@ public class DataService {
                             forEach((rpID) -> {
                         var representativeProposer = congressmanRepository.findLawmakerById(rpID)
                                 .orElseThrow(() -> new CongressmanException.CongressmanNotFound(Map.of("congressman", rpID)));
-                        updateRepresentativeProposer(newBill, representativeProposer);
+                                updateRepresentativeProposer(newBill, representativeProposer);
                             }
                     );
                 }
@@ -228,6 +228,7 @@ public class DataService {
                 var newBillProposer = BillProposer.builder()
                         .bill(newBill)
                         .congressman(billProposer)
+                        .party(billProposer.getParty())
                         .build();
 
                 billProposerRepository.save(newBillProposer);
@@ -244,11 +245,11 @@ public class DataService {
                 var repProposer = RepresentativeProposer.builder()
                         .bill(newBill)
                         .congressman(representativeProposer)
+                        .party(representativeProposer.getParty())
                         .build();
 
                 //RP 저장
                 representativeProposerRepository.save(repProposer);
-                congressmanRepository.save(representativeProposer);
 
         }
 


### PR DESCRIPTION
## 내용
법안 리팩토링 작업시, 법안정보의 발의 정당 역사성을 해결하기 위한 party_id필드가 추가됨에 따라
자동화 API에서 해당 사항을 반경하여 법안정보 삽입 시, party정보를 넣어주었음.