### PR TITLE
법안 투표 시 정당 득표 순 정렬

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillController.java
@@ -104,7 +104,7 @@ public class BillController {
             ),
     })
     @GetMapping("/detail/{bill_id}")
-    public BaseResponse<BillDetailResponse> getBillWtihDeatail(
+    public BaseResponse<BillDetailResponse> getBillWithDetail(
             @Parameter(example = "PRC_G2O3O1N2O1M1K1L5A0A8Z2Z2Y7W6X3")
             @PathVariable("bill_id") String billId) {
         var result = facade.getBillByBillId(billId);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -524,6 +524,7 @@ public class Facade {
                     var voteRecord = voteRecordService.getVoteRecordByBillId(bill.getId());
                     var votePartyList = votePartyService.getVotePartyListWithPartyByBillId(bill.getId()).stream()
                             .map(PartyVoteDto::from)
+
                             .toList();
                     var plenaryBill = PlenaryDto.of(bill, voteRecord, votePartyList);
                     plenaryBills.add(plenaryBill);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/VotePartyRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/VotePartyRepository.java
@@ -18,7 +18,9 @@ public interface VotePartyRepository extends JpaRepository<VoteParty,Long> {
     Optional<VoteParty> findByBillAndParty(@Param("billId") String billId, @Param("partyId") Long partyId);
 
     @Query("select vp from VoteParty vp " +
-            "join fetch vp.party " +
-            "where vp.bill.id = :billId ")
+            "join fetch vp.party p " +
+            "where vp.bill.id = :billId " +
+            "order by case when p.name = '무소속' then 1 else 0 end, " +
+            "vp.voteForCount desc ")
     List<VoteParty> findVotePartyWithPartyByBillId(@Param("billId") String billId);
 }


### PR DESCRIPTION
## 내용

### 정당 득표 순 정렬 로직 추가

SQL 정렬 로직 추가:
정당 이름이 "무소속"인 경우를 마지막으로 배치.
votes_for_count 컬럼 기준 내림차순 정렬.

```java
@Query("select vp from VoteParty vp " +
        "join fetch vp.party p " +
        "where vp.bill.id = :billId " +
        "order by case when p.name = '무소속' then 1 else 0 end, " +
        "vp.voteForCount desc ")
```

메서드명 findVotePartyWithPartyByBillId은 정당 정보와 함께 투표 데이터를 조회하도록 설계.