### PR TITLE
팔로잉 탭 최근 의원이 발의한 순서로 반환 적용

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/CongressmanRepository.java
@@ -19,7 +19,8 @@ public interface CongressmanRepository extends JpaRepository<Congressman, String
 
     @Query("SELECT c FROM Congressman c JOIN FETCH c.party " +
             "JOIN c.congressmanLike cl " +
-            "WHERE cl.user.id = :userId")
+            "WHERE cl.user.id = :userId " +
+            "order by c.congressmanBillProposeDate desc")
     List<Congressman> findLikingCongressmanByUserId(@Param("userId") long userId);
 
     @Query("SELECT c FROM Congressman c " +


### PR DESCRIPTION
## 내용

### 변경사항 팔로잉한 의원 정렬 로직 추가

findLikingCongressmanByUserId 메서드에 정렬 조건 추가:
사용자가 팔로우한(congressmanLike) 의원을 조회할 때, 최근 발의한 날짜(congressmanBillProposeDate) 기준으로 내림차순 정렬.

```java
@Query("SELECT c FROM Congressman c JOIN FETCH c.party " +
        "JOIN c.congressmanLike cl " +
        "WHERE cl.user.id = :userId " +
        "order by c.congressmanBillProposeDate desc")
List<Congressman> findLikingCongressmanByUserId(@Param("userId") long userId);
```

팔로잉 탭에서 의원의 최근 활동(법안 발의)을 기반으로 정렬하여 더 관련성 높은 정보를 제공합니다.