### PR TITLE
[FIX] 법안 API name필드와 imageUrl이 바뀌어서 나오는 문제 해결

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/proposer/RepresentativeProposerDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/proposer/RepresentativeProposerDto.java
@@ -27,14 +27,15 @@ public class RepresentativeProposerDto {
             String representativeProposerName,
             String representProposerImgUrl,
             long partyId,
-            String partyImageUrl,
-            String partyName) {
+            String partyName,
+            String partyImageUrl) {
         this.representativeProposerId = representativeProposerId;
         this.representativeProposerName = representativeProposerName;
         this.representProposerImgUrl = representProposerImgUrl;
         this.partyId = partyId;
-        this.partyImageUrl = partyImageUrl;
         this.partyName = partyName;
+        this.partyImageUrl = partyImageUrl;
+
     }
 
     public static RepresentativeProposerDto from(RepresentativeProposer representativeProposer) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
@@ -78,8 +78,8 @@ public class BillRepositoryImpl implements BillRepositoryCustom {
                                                 congressman.name,
                                                 congressman.congressmanImageUrl,
                                                 party.id,
-                                                party.partyImageUrl,
-                                                party.name
+                                                party.name,
+                                                party.partyImageUrl
                                         )
                                 ))
                 );
@@ -99,8 +99,8 @@ public class BillRepositoryImpl implements BillRepositoryCustom {
                                                 congressman.name,
                                                 congressman.congressmanImageUrl,
                                                 party.id,
-                                                party.partyImageUrl,
-                                                party.name
+                                                party.name,
+                                                party.partyImageUrl
                                         )
                                 ))
                 );


### PR DESCRIPTION
## 내용

### 법안 메인피드 조회 시 정당의 name필드와 imageUrl이 바뀌어서 나오는 문제 해결

공동발의자 정보에서 party_name과 party_image_url필드가 값이 바뀌어서 나오는 부분 해결
![image](https://github.com/user-attachments/assets/45dcf0ee-100d-4b2e-9913-f6e5e03e854e)
