### PR TITLE
[BE] 메인 피드를 제외한 대표 발의자의 party_image_url과 party_name이 바뀌어서 나오는 문제 해결

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/proposer/RepresentativeProposerDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/proposer/RepresentativeProposerDto.java
@@ -18,8 +18,8 @@ public class RepresentativeProposerDto {
     private String representProposerImgUrl;
 
     private long partyId;
-    private String partyImageUrl;
     private String partyName;
+    private String partyImageUrl;
 
     @QueryProjection
     public RepresentativeProposerDto(


### PR DESCRIPTION
## 내용

### 문제 내용
#394 
![image](https://github.com/user-attachments/assets/dc8f731a-2c27-4789-b9db-59da93cae24b)

### 메인 피드를 제외한 대표 발의자의 party_image_url과 party_name이 바뀌어서 나오는 문제 해결

대표발의자 데이터를 주입받는 DTO인 representativeProposerDto의 생성자 인자 순서를 바꿈으로써 해결

![image](https://github.com/user-attachments/assets/46a43240-6d69-4947-befe-e52a9be2b2b4)
