### PR TITLE
Feat(#billtimeline-bill-state)현재 국회의 법안 처리 상태 반환 API 완료

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillStateCountResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillStateCountResponse.java
@@ -1,5 +1,6 @@
 package com.everyones.lawmaking.common.dto.response;
 
+import com.everyones.lawmaking.global.constant.BillInfoConstant;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,16 +9,23 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BillStateCountResponse {
 
+    @Schema(name = "국회 개원으로부터 경과한 날")
+    private final Long daysSinceOpening;
     @Schema(name = "접수 법안")
-    private Integer receiptCount;
+    private final Long receiptCount;
     @Schema(name = "처리 법안")
-    private Integer treatmentCount;
+    private final Long treatmentCount;
     @Schema(name = "가결 법안")
-    private Integer passedCount;
+    private final Long passedCount;
+
+    public BillStateCountResponse(long receiptCount, long treatmentCount, long passedCount) {
+        this.daysSinceOpening = BillInfoConstant.getDaysSinceOpening();
+        this.receiptCount = receiptCount;
+        this.treatmentCount = treatmentCount;
+        this.passedCount = passedCount;
+    }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
@@ -1,6 +1,9 @@
 package com.everyones.lawmaking.controller;
 
 
+import com.everyones.lawmaking.common.dto.response.BillStateCountResponse;
+import com.everyones.lawmaking.common.dto.response.BillTimelineResponse;
+import com.everyones.lawmaking.facade.BillFacade;
 import com.everyones.lawmaking.facade.Facade;
 import com.everyones.lawmaking.global.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +31,7 @@ import static com.everyones.lawmaking.global.SwaggerConstants.EXAMPLE_ERROR_500_
 @Tag(name = "법안 타임라인 API", description = "법안 타임라인 API")
 public class BillTimelineController {
     private final Facade facade;
+    private final BillFacade billFacade;
 
     @Operation(summary = "타임라인 피드 조회", description = "타임라인에 들어갈 데이터를 가져옵니다.")
     @ApiResponses(value = {
@@ -43,7 +47,7 @@ public class BillTimelineController {
             ),
     })
     @GetMapping("/feed")
-    public BaseResponse<?> getTimeline(
+    public BaseResponse<BillTimelineResponse> getTimeline(
             @Parameter(example = "2024-08-02", description = "날짜별 법안 조회")
             @RequestParam(value = "billProposeDate", required = false)
             @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate billProposeDate
@@ -55,9 +59,22 @@ public class BillTimelineController {
         return BaseResponse.ok(result);
     }
 
-//    @GetMapping("/bill-state")
-//    public BaseResponse<?> getBillStateCount() {
-//        var result = facade.getBillStateCount();
-//        return BaseResponse.ok(result);
-//    }
+    @Operation(summary = "타임라인 법안 단계별 카운트 조회", description = "타임라인 법안 단계별 카운트 조회 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @GetMapping("/bill-state")
+    public BaseResponse<BillStateCountResponse> getBillStateCount() {
+        var result = billFacade.getBillStateCount();
+        return BaseResponse.ok(result);
+    }
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/BillFacade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/BillFacade.java
@@ -1,8 +1,11 @@
 package com.everyones.lawmaking.facade;
 
 import com.everyones.lawmaking.common.dto.response.BillListResponse;
+import com.everyones.lawmaking.common.dto.response.BillStateCountResponse;
+import com.everyones.lawmaking.common.dto.response.CountDto;
 import com.everyones.lawmaking.global.util.AuthenticationUtil;
 import com.everyones.lawmaking.service.BillService;
+import com.everyones.lawmaking.service.BillTimelineService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,11 @@ public class BillFacade {
     @Transactional(readOnly = true)
     public BillListResponse getBillList(Pageable pageable, String stage) {
         return billService.getBillList(pageable, stage);
+    }
+
+    @Transactional(readOnly = true)
+    public BillStateCountResponse getBillStateCount() {
+        return billService.getBillStateCount();
     }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/constant/BillInfoConstant.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/constant/BillInfoConstant.java
@@ -1,0 +1,24 @@
+package com.everyones.lawmaking.global.constant;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class BillInfoConstant {
+
+    private static final LocalDate OPENING_OF_THE_NATIONAL_ASSEMBLY = LocalDate.of(2024, 5, 30);
+
+    private static final int CURRENT_ASSEMBLY_NUMBER = 22;
+
+    public static int getCurrentAssemblyNumber() {
+        return CURRENT_ASSEMBLY_NUMBER;
+    }
+
+    public static LocalDate getOpeningOfTheNationalAssembly() {
+        return OPENING_OF_THE_NATIONAL_ASSEMBLY;
+    }
+
+    public static Long getDaysSinceOpening() {
+        return ChronoUnit.DAYS.between(OPENING_OF_THE_NATIONAL_ASSEMBLY, LocalDate.now());
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -141,8 +141,8 @@ public interface BillRepository extends JpaRepository<Bill, String>, BillReposit
 
     @Query("SELECT new com.everyones.lawmaking.common.dto.response.BillStateCountResponse(" +
             "COUNT(b), " +
-            "SUM(CASE WHEN b.stage IN ('위원회 심사', '본회의 심의', '체계자구 심사', '정부 이송', '공포') THEN 1 ELSE 0 END), " +
-            "SUM(CASE WHEN b.stage IN ('정부 이송', '공포') THEN 1 ELSE 0 END)) " +
+            "SUM(CASE WHEN b.stage IN ('위원회 심사', '본회의 심의', '체계자구 심사', '정부이송', '공포') THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN b.stage IN ('정부이송', '공포') THEN 1 ELSE 0 END)) " +
             "FROM Bill b "+
             "where b.assemblyNumber = :currentAssemblyNumber")
     BillStateCountResponse findStateCount(@Param("currentAssemblyNumber") int currentAssemblyNumber);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -139,7 +139,12 @@ public interface BillRepository extends JpaRepository<Bill, String>, BillReposit
             "WHERE b.id IN :billIds")
     List<Bill> findBillsWithPartiesByIds(@Param("billIds") List<String> billIds);
 
-    @Query("select b from Bill b ")
-    BillStateCountResponse findStateCount();
+    @Query("SELECT new com.everyones.lawmaking.common.dto.response.BillStateCountResponse(" +
+            "COUNT(b), " +
+            "SUM(CASE WHEN b.stage IN ('위원회 심사', '본회의 심의', '체계자구 심사', '정부 이송', '공포') THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN b.stage IN ('정부 이송', '공포') THEN 1 ELSE 0 END)) " +
+            "FROM Bill b "+
+            "where b.assemblyNumber = :currentAssemblyNumber")
+    BillStateCountResponse findStateCount(@Param("currentAssemblyNumber") int currentAssemblyNumber);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillService.java
@@ -5,6 +5,7 @@ import com.everyones.lawmaking.common.dto.bill.BillDto;
 import com.everyones.lawmaking.common.dto.proposer.RepresentativeProposerDto;
 import com.everyones.lawmaking.common.dto.response.*;
 import com.everyones.lawmaking.domain.entity.Bill;
+import com.everyones.lawmaking.global.constant.BillInfoConstant;
 import com.everyones.lawmaking.global.constant.BillOrderType;
 import com.everyones.lawmaking.global.error.BillException;
 import com.everyones.lawmaking.global.error.UserException;
@@ -224,7 +225,8 @@ public class BillService {
     }
 
     public BillStateCountResponse getBillStateCount() {
-        return billRepository.findStateCount();
+        int currentAssemblyNumber = BillInfoConstant.getCurrentAssemblyNumber();
+        return billRepository.findStateCount(currentAssemblyNumber);
     }
 
 


### PR DESCRIPTION
## 내용

### 기능 구현 사항
법안의 상태 카운트를 조회하는 기능을 추가하고, 이를 반환하는 API를 구현했습니다.

### 변경 내용

### BillStateCountResponse 클래스
BillStateCountResponse 클래스를 추가하여, 접수된 법안 수, 처리된 법안 수, 가결된 법안 수를 포함한 응답 객체를 정의했습니다. daysSinceOpening 값을 계산하여 국회 개원일로부터 경과된 일수를 반환하는 필드를 추가했습니다.
### BillTimelineController(/v1/bill-timeline/bill-state)
/bill-state 경로에 법안 상태별 카운트를 조회하는 API를 추가했습니다. 이 API는 BillFacade를 통해 법안 상태별 카운트를 반환하며, 결과는 BillStateCountResponse 형태로 반환됩니다.
getBillStateCount() 메소드를 추가하여 BillRepository의 findStateCount() 메소드를 호출하여 법안 상태별 카운트를 반환합니다.
### BillRepository 클래스
findStateCount() 쿼리를 수정하여 BillStateCountResponse 객체를 반환하도록 했습니다. stage 값을 기준으로 법안을 필터링하고, 접수된 법안 수, 처리된 법안 수, 가결된 법안 수를 계산하여 반환합니다.

### BillInfoConstant 클래스
- 국회 개원일로부터 경과된 일수를 계산하는 getDaysSinceOpening() 메소드를 추가했습니다.
