### PR TITLE
Fix(#Congressman-#Representative- dateColumns) 데이터 생성, 수정 날짜 필드 누락

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Congressman.java
@@ -17,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class Congressman {
+public class Congressman extends BaseEntity{
     @Version
     private Long version;
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/RepresentativeProposer.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/RepresentativeProposer.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RepresentativeProposer {
+public class RepresentativeProposer  extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 내용
의원과 대표발의자 테이블에 날짜 컬럼(수정, 생성) 컬럼이 누락되어 있어,
해당 필드를 가진 BaseEntity를 각 클래스가 상속시켰습니다.
