### PR TITLE
Fix(#Notification) 데이터 쓰기 이벤트 시 반응 안함.

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/TableEventListener.java
@@ -165,7 +165,7 @@ public class TableEventListener {
                                             .filter(wce -> tableName.equalsIgnoreCase(wce.getTableName())
                                                     && wce.getEventType() == ColumnEventType.EventType.INSERT)
                                             .map(wce -> {
-                                                final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName, new HashMap<>());
+                                                final Map<String, Integer> columnOrdersForTable = columnOrdersByTable.getOrDefault(tableName.toLowerCase(), new HashMap<>());
                                                 return new AbstractMap.SimpleEntry<>(
                                                         wce.getEventName(),
                                                         wce.getKeyColumns()


### PR DESCRIPTION
## 내용
팔로우한 의원의 대표발의 법안이 발의되었을때, 알림 데이터가 생성되지 않았습니다.
확인 해보니, 원격 디비의 테이블 이름은 lowercase로 바꿔주지않아 인식하지 않았습니다.
이에 TableEventListenr.class의 해당 부분을 수정해주었습니다.

## 기타
알림 쪽 로직을 리팩토링하고 테스트코드를 작성해야할 필요가 보입니다.