### PR TITLE
Feat(#BillTimeline-paging) 타임라인 페이징 기능 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
@@ -14,7 +14,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,6 +48,7 @@ public class BillTimelineController {
                     )}
             ),
     })
+    @Deprecated
     @GetMapping("/feed")
     public BaseResponse<BillTimelineResponse> getTimeline(
             @Parameter(example = "2024-08-02", description = "날짜별 법안 조회")
@@ -56,6 +59,17 @@ public class BillTimelineController {
             billProposeDate = LocalDate.now();
         }
         var result = facade.getTimeline(billProposeDate);
+        return BaseResponse.ok(result);
+    }
+    @GetMapping("/feed/paging")
+    public BaseResponse<List<BillTimelineResponse>> getTimelinePaging(
+            @Parameter(example = "0", description = "페이지 넘버")
+            @RequestParam(value = "page") int page,
+            @Parameter(example = "2", description = "불러올 날짜 개수")
+            @RequestParam(value = "size") int size
+    ) {
+        var pageable = PageRequest.of(page, size);
+        var result = facade.getTimeline(pageable);
         return BaseResponse.ok(result);
     }
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -502,6 +502,15 @@ public class Facade {
         return setBillListResponseBookMark(billList);
     }
     @Transactional(readOnly = true)
+    public List<BillTimelineResponse> getTimeline(Pageable pageable) {
+        var timelineDateList = billTimelineService.getDatePaging(pageable);
+        List<BillTimelineResponse> timelineList = new ArrayList<>();
+        for (LocalDate timelineDate : timelineDateList) {
+            timelineList.add(getTimeline(timelineDate));
+        }
+        return timelineList;
+    }
+    @Transactional(readOnly = true)
     public BillTimelineResponse getTimeline(LocalDate proposeDate) {
         var submittedBills = getSubmittedBills(proposeDate);
         var plenaryBills  = getPlenaryBills(proposeDate);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillTimelineRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillTimelineRepository.java
@@ -1,16 +1,15 @@
 package com.everyones.lawmaking.repository;
 
-import com.everyones.lawmaking.common.dto.PromulgationDto;
 import com.everyones.lawmaking.domain.entity.BillTimeline;
 import jakarta.persistence.Tuple;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface BillTimelineRepository extends JpaRepository<BillTimeline,Long> {
@@ -36,5 +35,9 @@ public interface BillTimelineRepository extends JpaRepository<BillTimeline,Long>
     List<String> findBillTimelineBetweenProposeDateAndStage(@Param("proposeDate") LocalDate localDate, @Param("stage") String stage);
 
     List<BillTimeline> findByBillIdAndBillTimelineStageAndBillResult(String bill_id, String billTimelineStage, String billResult);
+
+    @Query("SELECT DISTINCT bl.statusUpdateDate FROM BillTimeline bl " +
+            "ORDER BY bl.statusUpdateDate DESC")
+    List<LocalDate> findTop3ProposeDates(Pageable pageable);
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillTimelineService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillTimelineService.java
@@ -3,6 +3,7 @@ package com.everyones.lawmaking.service;
 import com.everyones.lawmaking.common.dto.projection.CommitteeBillDto;
 import com.everyones.lawmaking.repository.BillTimelineRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -40,5 +41,9 @@ public class BillTimelineService {
                     List<String> billIds = Arrays.asList(billIdsConcat.split(","));
                     return CommitteeBillDto.of(committee, billIds);
                 }).toList();
+    }
+
+    public List<LocalDate> getDatePaging(Pageable pageable) {
+        return billTimelineRepository.findTop3ProposeDates(pageable);
     }
 }


### PR DESCRIPTION
## 내용

타임라인을 불러오는 API를 날짜 기준이 아닌 페이징을 기준으로 호출 가능하도록 변경하였습니다.

### 세부 사항
아래와 같이 2월 22일의 경우 토요일은 주말이라 호출이 되더라도 데이터가 없는 경우가 존재합니다.
![image](https://github.com/user-attachments/assets/1a7f61d1-6a4d-4ccb-9091-5aa908e052bd)

페이징을 기준으로 API를 호출하게 되면 데이터가 존재하는 날짜만 반환되어 프론트에서 해당 날짜 예외 처리를 할 필요가 없어집니다. 

데이터를 불러오는 양 자체가 많기 때문에, 페이지 당 불러오는 날짜의 크기를 2개정도로 하는 것이 좋아보임. 그래도 1.6초 이상 걸림

그래서 데이터를 많이 불러오는 것을 감안하더라도 성능 향상을 할 수 있는 방법을 추가로 고안해야됨.
