### PR TITLE
Feat(#billTimeline-bill-stage) 타임라인 stage에 새로운 값이 들어올 경우 해결

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Bill.java
@@ -135,7 +135,6 @@ import java.util.List;
         BillStageType currentStage = BillStageType.fromValue(this.stage);
         BillStageType nextStage = BillStageType.fromValue(billStageDfRequest.getStage());
 
-
         // 단계의 order가 커야 수정 가능 (심의 단계가 다음 단계일 때만 수정이 가능.)
         if (BillStageType.canUpdateStage(currentStage, nextStage)) {
             this.setStage(billStageDfRequest.getStage());

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/constant/BillStageType.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/constant/BillStageType.java
@@ -4,50 +4,142 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.AllArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-public enum BillStageType {
-    RECEIPT(1,"접수", "접수"),
-    STANDING_COMMITTEE_RECEIPT(2,"위원회 심사","소관위접수"),
-    STANDING_COMMITTEE_AUDIT_BEFORE(3,"위원회 심사","위원회 심사"),
-    SYSTEMATIC_REVIEW(4,"체계자구 심사", "체계자구 심사"),
-    PLENARY_SESSION(5,"본회의 심의","본회의 심의"),
-    GOVERNMENT_TRANSFER(6, "정부이송","정부이송"),
-    PROMULGATION(7,"공포","공포");
-
-    private int order;
-    private String key;
-    private String value;
+public class BillStageType {
+    // 상수 정의
+    public static final BillStageType WITHDRAWAL = new BillStageType(0, "철회", "철회");
+    public static final BillStageType RECEIPT = new BillStageType(1, "접수", "접수");
+    public static final BillStageType STANDING_COMMITTEE_RECEIPT = new BillStageType(2, "위원회 심사", "소관위접수");
+    public static final BillStageType STANDING_COMMITTEE_AUDIT_BEFORE = new BillStageType(3, "위원회 심사", "위원회 심사");
+    public static final BillStageType SYSTEMATIC_REVIEW = new BillStageType(4, "체계자구 심사", "체계자구 심사");
+    public static final BillStageType PLENARY_SESSION = new BillStageType(5, "본회의 심의", "본회의 심의");
+    public static final BillStageType GOVERNMENT_TRANSFER = new BillStageType(6, "정부이송", "정부이송");
+    public static final BillStageType PROMULGATION = new BillStageType(7, "공포", "공포");
 
     private static final Map<String, List<String>> KEY_MAP = new HashMap<>();
+    private static final List<BillStageType> PREDEFINED_STAGES = new ArrayList<>();
+    private static final Map<String, BillStageType> VALUE_MAP = new HashMap<>();
 
     static {
-        for (BillStageType e : BillStageType.values()) {
-            KEY_MAP.computeIfAbsent(e.key, k -> new ArrayList<>()).add(e.value);
+        PREDEFINED_STAGES.add(WITHDRAWAL);
+        PREDEFINED_STAGES.add(RECEIPT);
+        PREDEFINED_STAGES.add(STANDING_COMMITTEE_RECEIPT);
+        PREDEFINED_STAGES.add(STANDING_COMMITTEE_AUDIT_BEFORE);
+        PREDEFINED_STAGES.add(SYSTEMATIC_REVIEW);
+        PREDEFINED_STAGES.add(PLENARY_SESSION);
+        PREDEFINED_STAGES.add(GOVERNMENT_TRANSFER);
+        PREDEFINED_STAGES.add(PROMULGATION);
+
+        for (BillStageType stage : PREDEFINED_STAGES) {
+            KEY_MAP.computeIfAbsent(stage.getKey(), k -> new ArrayList<>()).add(stage.getValue());
+            VALUE_MAP.put(stage.getValue(), stage);
         }
     }
 
+    @Getter
+    private final int order;
+
+    @Getter
+    private final String key;
+
+    @Getter
+    private final String value;
+
+    @Getter
+    private final boolean predefined;
+
+    // 사전 정의된 단계 생성자
+    private BillStageType(int order, String key, String value) {
+        this.order = order;
+        this.key = key;
+        this.value = value;
+        this.predefined = true;
+    }
+
+    // 사전 정의되지 않은 단계 생성자
+    private BillStageType(String key, String value) {
+        this.order = -1; // 사전 정의되지 않은 단계는 순서를 -1로 표시
+        this.key = key;
+        this.value = value;
+        this.predefined = false;
+    }
+
+    /**
+     * 현재 단계에서 다음 단계로 업데이트 가능한지 확인
+     * 1. 사전 정의된 단계 간 이동: 순서가 증가하는 방향으로만 가능
+     * 2. 사전 정의되지 않은 단계로 이동: 항상 가능
+     */
     public static boolean canUpdateStage(BillStageType current, BillStageType next) {
+        // 대상 단계가 사전 정의되지 않은 경우 항상 업데이트 가능
+        if (!next.isPredefined()) {
+            return true;
+        }
+
+        // 현재 단계가 사전 정의되지 않은 경우, 사전 정의된 단계로 항상 업데이트 가능
+        if (!current.isPredefined()) {
+            return true;
+        }
+
+        // 둘 다 사전 정의된 단계인 경우, 순서가 증가해야만 업데이트 가능
         return current.getOrder() < next.getOrder();
     }
 
+    /**
+     * value로 BillStageType 찾기
+     * 사전 정의된 단계에 없으면 새로운 BillStageType 생성
+     */
     public static BillStageType fromValue(String value) {
-        for (BillStageType stage : BillStageType.values()) {
-            if (stage.getValue().equals(value)) {
-                return stage;
-            }
+        BillStageType stage = VALUE_MAP.get(value);
+        if (stage != null) {
+            return stage;
         }
-        throw new IllegalArgumentException("No Found enum constant with value " + value);
+
+        // 사전 정의된 단계에 없는 경우 새로운 단계 생성
+        // 여기서는 key와 value를 동일하게 설정
+        return new BillStageType(value, value);
     }
 
+    /**
+     * 지정된 key에 해당하는 단계가 존재하는지 확인
+     */
     public static boolean containsValue(String stage) {
         return KEY_MAP.containsKey(stage);
     }
 
-    public static List<String> getValueList(String stage) {
-        return KEY_MAP.get(stage);
+    /**
+     * 사전 정의된 단계에 새로운 단계 추가 (확장 가능성)
+     */
+    public static void registerPredefinedStage(BillStageType stage) {
+        if (!PREDEFINED_STAGES.contains(stage)) {
+            PREDEFINED_STAGES.add(stage);
+            KEY_MAP.computeIfAbsent(stage.getKey(), k -> new ArrayList<>()).add(stage.getValue());
+            VALUE_MAP.put(stage.getValue(), stage);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        BillStageType that = (BillStageType) obj;
+        return value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "BillStageType{" +
+                "order=" + order +
+                ", key='" + key + '\'' +
+                ", value='" + value + '\'' +
+                ", predefined=" + predefined +
+                '}';
     }
 }


### PR DESCRIPTION
## 내용
✅ 주요 변경사항
BillStageType을 enum에서 클래스로 리팩토링하여 유연성 강화

기존 enum 기반 구조에서는 사전 정의된 단계만 처리 가능했음

사전 정의되지 않은 단계도 처리 가능하도록 구조 개선 (predefined 플래그 추가)

fromValue() 메서드에서 사전 정의되지 않은 값도 허용

canUpdateStage() 로직 수정

사전 정의되지 않은 단계 간 이동도 허용

정의된 단계 간에는 order 기준으로 판단

registerPredefinedStage() 메서드 추가로 런타임 중 단계 확장 가능

equals() 오버라이드로 객체 비교 안정화

🔧 영향
비정형 단계(ex. 사용자 정의 단계)도 처리 가능하여 입법 절차 유연성 향상

유지보수성 및 확장성 향상

📝 기타
기존 enum 기반 방식은 values() 등의 기능 제한이 있어, 단계 변경 처리에 제약이 있었습니다.

본 변경은 신규 입법 절차 대응이나 외부 연동 시 유연하게 대처하기 위함입니다.