### PR TITLE
Fix(#Billtimeline-pagination) BillTimeline 페이징 객체 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillTimelinePaginationResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/BillTimelinePaginationResponse.java
@@ -1,0 +1,27 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BillTimelinePaginationResponse {
+
+    PaginationResponse paginationResponse;
+
+    List<BillTimelineResponse> timelineResponseList;
+
+    public static BillTimelinePaginationResponse of(PaginationResponse paginationResponse, List<BillTimelineResponse> timelineResponseList) {
+        return BillTimelinePaginationResponse.builder()
+                .paginationResponse(paginationResponse)
+                .timelineResponseList(timelineResponseList)
+                .build();
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/BillTimelineController.java
@@ -2,6 +2,7 @@ package com.everyones.lawmaking.controller;
 
 
 import com.everyones.lawmaking.common.dto.response.BillStateCountResponse;
+import com.everyones.lawmaking.common.dto.response.BillTimelinePaginationResponse;
 import com.everyones.lawmaking.common.dto.response.BillTimelineResponse;
 import com.everyones.lawmaking.facade.BillFacade;
 import com.everyones.lawmaking.facade.Facade;
@@ -62,7 +63,7 @@ public class BillTimelineController {
         return BaseResponse.ok(result);
     }
     @GetMapping("/feed/paging")
-    public BaseResponse<List<BillTimelineResponse>> getTimelinePaging(
+    public BaseResponse<BillTimelinePaginationResponse> getTimelinePaging(
             @Parameter(example = "0", description = "페이지 넘버")
             @RequestParam(value = "page") int page,
             @Parameter(example = "2", description = "불러올 날짜 개수")

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -502,13 +502,14 @@ public class Facade {
         return setBillListResponseBookMark(billList);
     }
     @Transactional(readOnly = true)
-    public List<BillTimelineResponse> getTimeline(Pageable pageable) {
+    public BillTimelinePaginationResponse getTimeline(Pageable pageable) {
         var timelineDateList = billTimelineService.getDatePaging(pageable);
+        PaginationResponse paginationResponse = PaginationResponse.from(timelineDateList);
         List<BillTimelineResponse> timelineList = new ArrayList<>();
         for (LocalDate timelineDate : timelineDateList) {
             timelineList.add(getTimeline(timelineDate));
         }
-        return timelineList;
+        return BillTimelinePaginationResponse.of(paginationResponse, timelineList);
     }
     @Transactional(readOnly = true)
     public BillTimelineResponse getTimeline(LocalDate proposeDate) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillTimelineRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillTimelineRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,7 +46,7 @@ public interface BillTimelineRepository extends JpaRepository<BillTimeline,Long>
 
     @Query("SELECT DISTINCT bl.statusUpdateDate FROM BillTimeline bl " +
             "ORDER BY bl.statusUpdateDate DESC")
-    List<LocalDate> findTopProposeDates(Pageable pageable);
+    Slice<LocalDate> findTopProposeDates(Pageable pageable);
 
     LocalDate findTopByOrderByStatusUpdateDateDesc();
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/BillTimelineService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/BillTimelineService.java
@@ -4,6 +4,7 @@ import com.everyones.lawmaking.common.dto.projection.CommitteeBillDto;
 import com.everyones.lawmaking.repository.BillTimelineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -43,7 +44,7 @@ public class BillTimelineService {
                 }).toList();
     }
 
-    public List<LocalDate> getDatePaging(Pageable pageable) {
+    public Slice<LocalDate> getDatePaging(Pageable pageable) {
         return billTimelineRepository.findTopProposeDates(pageable);
     }
 }


### PR DESCRIPTION
## 내용

1. 법안 타임라인 페이지네이션 응답 객체(BillTimelinePaginationResponse) 추가.

페이지네이션 정보와 타임라인 데이터를 함께 반환할 수 있도록 설계.

페이지네이션 객체를 통해 프론트에서 지속적으로 페이징 API를 호출할 수 있도록 변경