### PR TITLE
Feat(#Party-Executive) 정당 간부 API 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyExecutiveResponse.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/response/PartyExecutiveResponse.java
@@ -1,0 +1,34 @@
+package com.everyones.lawmaking.common.dto.response;
+
+import com.everyones.lawmaking.domain.entity.Party;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PartyExecutiveResponse {
+    @Schema(description = "당대표", example = "이재명")
+    String partyLeader;
+    @Schema(description = "원내대표", example = "박찬대")
+    String parliamentaryLeader;
+    @Schema(description = "정책위의장", example = "진성준")
+    String policyCommitteeChairman;
+    @Schema(description = "사무총장", example = "박찬대")
+    String secretaryGeneral;
+
+    public static PartyExecutiveResponse from(Party party) {
+        return PartyExecutiveResponse.builder()
+                .partyLeader(party.getPartyLeader())
+                .parliamentaryLeader(party.getParliamentaryLeader())
+                .policyCommitteeChairman(party.getPolicyCommitteeChairman())
+                .secretaryGeneral(party.getSecretaryGeneral())
+                .build();
+    }
+
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/PartyController.java
@@ -149,6 +149,27 @@ public class PartyController {
         var result = facade.getParliamentaryParty();
         return BaseResponse.ok(result);
     }
+    @Operation(summary = "정당 간부 조회", description = "당대표, 사무총장 등 정당 간부 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (문제 지속시 BE팀 문의)",
+                    content = {@Content(
+                            mediaType = "application/json;charset=UTF-8",
+                            schema = @Schema(implementation = BaseResponse.class),
+                            examples = @ExampleObject(value = EXAMPLE_ERROR_500_CONTENT)
+                    )}
+            ),
+    })
+    @GetMapping("/executive")
+    public BaseResponse<PartyExecutiveResponse> getPartyExecutive(
+            @Parameter(example = "1", description = "정당 Id")
+            @RequestParam("party_id") int partyId
+    ) {
+        var result = facade.getPartyExecutive(partyId);
+        return BaseResponse.ok(result);
+    }
 
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -5,6 +5,7 @@ import com.everyones.lawmaking.common.dto.bill.BillDto;
 import com.everyones.lawmaking.common.dto.request.*;
 import com.everyones.lawmaking.common.dto.response.*;
 import com.everyones.lawmaking.domain.entity.ColumnEventType;
+import com.everyones.lawmaking.domain.entity.Party;
 import com.everyones.lawmaking.domain.entity.ProposerKindType;
 import com.everyones.lawmaking.domain.entity.User;
 import com.everyones.lawmaking.global.error.AuthException;
@@ -591,6 +592,11 @@ public class Facade {
 
     public List<ParliamentaryPartyResponse> getParliamentaryParty() {
         return partyService.getParliamentaryParty();
+    }
+
+    public PartyExecutiveResponse getPartyExecutive(int partyId) {
+        Party party = partyService.findById(partyId);
+        return PartyExecutiveResponse.from(party);
     }
 
 


### PR DESCRIPTION
### PR 요약: 정당 간부 조회 기능 추가

#### 주요 변경 사항

1. **새로운 DTO 클래스 추가**:

   * `PartyExecutiveResponse` 클래스 생성:

     * 정당 간부 정보를 담는 DTO로, 당대표, 원내대표, 정책위의장, 사무총장 필드를 포함.
     * 정당 엔티티(`Party`)로부터 데이터를 매핑하는 `from` 메서드 제공.

2. **컨트롤러에 API 추가**:

   * `PartyController`에 새로운 정당 간부 조회 API 추가:

     * **Endpoint**: `/party/executive`
     * **Request Parameter**: `party_id` (정당 ID)
     * **Response**: `PartyExecutiveResponse` 형식으로 당대표, 원내대표 등 주요 간부 정보를 반환.

3. **Facade 계층에 비즈니스 로직 추가**:

   * `Facade` 클래스에 `getPartyExecutive` 메서드 추가:

     * 정당 ID를 기반으로 `Party` 엔티티를 조회하고, 해당 데이터를 `PartyExecutiveResponse`로 변환하여 반환.

#### API 사양

* **HTTP Method**: GET
* **URL**: `/party/executive`
* **Request Parameter**:

  * `party_id` (정당 ID, 필수)
* **Response**:

  ```json
  {
    "party_leader": "이재명",
    "parliamentary_leader": "박찬대",
    "policy_committee_chairman": "진성준",
    "secretary_general": "박찬대"
  }
  ```
* **Status Codes**:

  * `200`: 조회 성공
  * `500`: 서버 오류 (문제 지속 시 BE팀 문의)

#### 기능적 개선 효과

* **정당 간부 정보 제공**: 정당 주요 간부 정보를 조회할 수 있는 명확한 API 제공.
* **확장성 및 재사용성 강화**: DTO와 Facade 계층 설계를 통해 유지보수와 추가 기능 구현이 용이.
