### PR TITLE
Fix/notification/representative

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -265,10 +265,12 @@ public class Facade {
         var billId = bill.getId();
         var billBriefSummary = bill.getBriefSummary();
         String partyName = NullUtil.nullCoalescing(() -> congressman.getParty().getName(), "defaultPartyName");
-        var congressmanInfo = partyName+":"+congressman.getCongressmanImageUrl();
+        String partyId = NullUtil.nullCoalescing(() -> String.valueOf(congressman.getParty().getId()), "defaultPartyImageUrl");
+        var congressmanInfo = partyName+":"+congressman.getId();
+        var partyInfo = partyName+":"+partyId;
 
 
-        return List.of(billId, congressmanName, billBriefSummary, congressmanInfo);
+        return List.of(billId, congressmanName, billBriefSummary, congressmanInfo, partyInfo);
     }
 
 

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/Facade.java
@@ -262,12 +262,13 @@ public class Facade {
         }
         var congressman = congressmanService.findById(uniqueKeys.get(0));
         var congressmanName = congressman.getName();
+        var party = congressman.getParty();
         var billId = bill.getId();
         var billBriefSummary = bill.getBriefSummary();
-        String partyName = NullUtil.nullCoalescing(() -> congressman.getParty().getName(), "defaultPartyName");
-        String partyId = NullUtil.nullCoalescing(() -> String.valueOf(congressman.getParty().getId()), "defaultPartyImageUrl");
-        var congressmanInfo = partyName+":"+congressman.getId();
-        var partyInfo = partyName+":"+partyId;
+        String partyName = NullUtil.nullCoalescing(party::getName, "defaultPartyName");
+        String partyImageUrl = NullUtil.nullCoalescing(party::getPartyImageUrl, "defaultPartyImageUrl");
+        var congressmanInfo = partyName+":"+congressman.getCongressmanImageUrl();
+        var partyInfo = partyName+":"+partyImageUrl;
 
 
         return List.of(billId, congressmanName, billBriefSummary, congressmanInfo, partyInfo);

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/util/NotificationConverter.java
@@ -54,7 +54,7 @@ public class NotificationConverter {
 
                 title = data.get(1) + " 의원";
                 content = "'"+data.get(2) + "' 법안을 대표 발의했어요!";
-                notificationImageUrlList.add(data.get(3));
+                notificationImageUrlList.addAll(data.subList(3, data.size()));
                 break;
             case BILL_STAGE_UPDATE:
 


### PR DESCRIPTION
# PR 요약: 대표발의 알림 메시지 기능 확장 및 이미지 처리 로직 개선

## 주요 변경 사항

1. **알림 데이터에 정당 정보(`partyInfo`) 추가**  
   - `insertRepresentativeBill(..)` 반환값에 기존의 `[billId, congressmanName, billBriefSummary, congressmanInfo]` 외에  
   - **`partyInfo`(정당명 + 정당 이미지 URL)**을 추가로 포함하도록 수정  

2. **NotificationConverter의 이미지 처리 로직 개선**  
   - **변경 전**:  
     ```java
     notificationImageUrlList.add(data.get(3));
     ```  
     - 단일 이미지 URL만 수집  
   - **변경 후**:  
     ```java
     notificationImageUrlList.addAll(data.subList(3, data.size()));
     ```  
     - 인덱스 3 이후 모든 이미지 URL을 한꺼번에 수집 가능  

## 변경 후 코드의 주요 장점

- **알림 내용 풍부화**  
  - 의원 정보 외에 소속 정당 정보까지 포함되어 사용자에게 더 정확한 컨텍스트 제공  
- **멀티 이미지 지원**  
  - 다수의 이미지 URL을 리스트에 한 번에 추가함으로써, 다양한 알림 이미지를 유연하게 처리  
- **코드 간결화**  
  - `subList`와 `addAll` 활용으로 반복문이나 별도 로직 없이 간단히 다중 추가 구현  

## 변경 전/후 비교

### 1. `insertRepresentativeBill` 반환값

- **변경 전**
  ```java
  return List.of(
      billId,
      congressmanName,
      billBriefSummary,
      congressmanInfo
  );

- **변경 후**
  ```java
  return List.of(
      billId,
      congressmanName,
      billBriefSummary,
      congressmanInfo,
      partyInfo
  );

### 2. `NotificationConverter` 이미지 처리

- **변경 전**
  ```java
  case REPRESENTATIVE_BILL:
      // ...
      notificationImageUrlList.add(data.get(3));
      break;

- **변경 후**
  ```java
  case REPRESENTATIVE_BILL:
      // ...
      notificationImageUrlList.addAll(data.subList(3, data.size()));
      break;

### 기능적 개선 효과

- 콘텐츠 강화: 알림에 정당 정보가 추가되어 수신자가 소속 정당까지 한눈에 파악 가능

- 유연성 증가: 단일 → 다중 이미지 처리로, 향후 이미지 구성 변경 시에도 코드 수정 최소화

- 유지보수 용이: 간결한 컬렉션 조작으로 로직 가독성이 높아지고, 확장 요구 사항 대응이 쉬워짐
