### PR TITLE
Feat(#mainfeed-notification) 메인피드용 알람 추가

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/controller/NotificationController.java
@@ -48,6 +48,13 @@ public class NotificationController {
         return BaseResponse.ok(result);
     }
 
+    @GetMapping("/top3-unread")
+    public BaseResponse<List<NotificationResponse>> getTop3UnreadNotifications(Authentication authentication) {
+        final UserDetails user = (UserDetails) authentication.getPrincipal();
+        var result = notificationFacade.getTop3UnreadNotifications(Long.parseLong(user.getUsername()));
+        return BaseResponse.ok(result);
+    }
+
     @Operation(summary = "알림 읽음 처리 API", description = "모든 알림을 읽음 처리")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "읽음 성공"),

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/NotificationFacade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/NotificationFacade.java
@@ -30,6 +30,10 @@ public class NotificationFacade {
         return notificationService.getNotifications(userId);
     }
 
+    public List<NotificationResponse> getTop3UnreadNotifications(long userId) {
+        return notificationService.getTop3UnreadNotifications(userId);
+    }
+
     public List<NotificationResponse> readAllNotifications(long userId) {
         return notificationService.readNotification(userId, Optional.empty());
     }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/NotificationRepository.java
@@ -26,6 +26,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
             select n
             from Notification n
+            join n.user u
+            where u.id = :userId and n.isRead = false
+            order by n.createdDate desc
+            limit 3
+            """)
+    List<Notification> findTop3UnreadNotificationsByUserIdSorted(@Param("userId") Long userId);
+    @Query("""
+            select n
+            from Notification n
             Join n.user u
             where u.id = :userId
             order by n.createdDate desc

--- a/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/service/NotificationService.java
@@ -26,6 +26,12 @@ public class NotificationService {
         return NotificationResponse.from(notifications);
     }
 
+    public List<NotificationResponse> getTop3UnreadNotifications(long userId) {
+        List<Notification> notifications = notificationRepository.findTop3UnreadNotificationsByUserIdSorted(userId);
+
+        return NotificationResponse.from(notifications);
+    }
+
 
 
 


### PR DESCRIPTION
### 변경사항 요약:

1. **컨트롤러 변경:**

   * `NotificationController`에 `/top3-unread` 엔드포인트 추가: 사용자의 상위 3개의 읽지 않은 알림을 가져오는 기능 구현.

2. **Facade 레이어:**

   * `NotificationFacade`에 `getTop3UnreadNotifications` 메서드 추가: 서비스 레이어로 작업 위임.

3. **레포지토리 레이어:**

   * `NotificationRepository`에 `findTop3UnreadNotificationsByUserIdSorted` 메서드 추가: 읽지 않은 알림 중 최신 3개를 가져오는 JPQL 쿼리 작성.

4. **서비스 레이어:**

   * `NotificationService`에 `getTop3UnreadNotifications` 메서드 구현: 읽지 않은 알림을 가져와 응답 DTO로 변환.

5. **쿼리 설계:**

   * `LIMIT 3`와 같은 SQL 기능을 활용하여 주어진 사용자 ID에 대한 최신 읽지 않은 알림 3개를 반환.

---

### 변경사항의 장점:

* 최신 3개의 읽지 않은 알림만 효율적으로 가져와 데이터 처리량 감소.
* 사용자 경험(UI/UX) 측면에서 간결하고 중요한 정보를 빠르게 제공 가능.

---

### 개선 제안:

1. **캐싱 도입:**

   * 알림 데이터가 자주 변경되지 않는 경우, 캐싱을 활용하여 성능을 향상시킬 수 있음.

2. **에러 처리:**

   * 사용자 정보가 없거나 읽지 않은 알림이 없을 때 예외 상황에 대한 처리 추가.

3. **페이징 지원:**

   * 이후 요구사항이 확장될 경우, 페이징 처리 또는 동적인 제한(예: TOP N)을 지원하도록 수정 가능.
