### PR TITLE
Fix(#bill_result) Bill-detail 수정 완료

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDetailInfo.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillDetailInfo.java
@@ -4,11 +4,8 @@ import com.everyones.lawmaking.domain.entity.Bill;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
@@ -17,11 +14,13 @@ import java.time.LocalDate;
 public class BillDetailInfo extends BillInfoDto{
 
     private String billLink;
+    private String billResult;
 
 
     public BillDetailInfo(Bill bill) {
         super(bill);
         this.billLink = bill.getBillLink();
+        this.billResult = bill.getBillResult();
     }
 
     public static BillDetailInfo from(Bill bill) {

--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/BillInfoDto.java
@@ -5,12 +5,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Builder
 @Getter
@@ -29,7 +28,6 @@ public class BillInfoDto {
     private int billLikeCount;
     private String billStage;
     private String briefSummary;
-    private String billResult;
 
     @QueryProjection
     public BillInfoDto(Bill bill) {
@@ -57,9 +55,6 @@ public class BillInfoDto {
                 .billStage(bill.getStage())
                 .briefSummary(bill.getBriefSummary())
                 .build();
-    }
-    public void setBillResult(String billResult) {
-        this.billResult = billResult;
     }
 
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/facade/BillFacade.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/facade/BillFacade.java
@@ -3,23 +3,29 @@ package com.everyones.lawmaking.facade;
 import com.everyones.lawmaking.common.dto.PartyVoteDto;
 import com.everyones.lawmaking.common.dto.VoteResultResponse;
 import com.everyones.lawmaking.common.dto.bill.BillDto;
-import com.everyones.lawmaking.common.dto.response.*;
+import com.everyones.lawmaking.common.dto.response.BillDetailResponse;
+import com.everyones.lawmaking.common.dto.response.BillListResponse;
+import com.everyones.lawmaking.common.dto.response.BillStateCountResponse;
+import com.everyones.lawmaking.common.dto.response.BillViewCountResponse;
+import com.everyones.lawmaking.common.dto.response.CountDto;
 import com.everyones.lawmaking.global.util.AuthenticationUtil;
-import com.everyones.lawmaking.service.*;
+import com.everyones.lawmaking.service.BillService;
+import com.everyones.lawmaking.service.LikeService;
+import com.everyones.lawmaking.service.RedisService;
+import com.everyones.lawmaking.service.VotePartyService;
+import com.everyones.lawmaking.service.VoteRecordService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class BillFacade {
     private final BillService billService;
-    private final BillTimelineService billTimelineService;
     private final LikeService likeService;
     private final VoteRecordService voteRecordService;
     private final VotePartyService votePartyService;
@@ -27,8 +33,6 @@ public class BillFacade {
 
     public BillDetailResponse getBillByBillId(String billId) {
         var billDto =  billService.getBillWithDetail(billId);
-        var billResult = billTimelineService.getRecentBillResult(billId);
-        billDto.getBillInfoDto().setBillResult(billResult);
         var userId = AuthenticationUtil.getUserId();
         var voteRecord = voteRecordService.getVoteRecordByBillId(billId);
         var votePartyList = votePartyService.getVotePartyListWithPartyByBillId(billId).stream()


### PR DESCRIPTION
### 변경사항 요약:

1. **`BillDetailInfo` DTO 수정:**

   * `billResult` 필드 추가.
   * 생성자에서 `billResult` 값을 Bill 엔티티에서 가져오도록 설정.
   * `setBillResult` 메서드 제거.

2. **`BillInfoDto` DTO 수정:**

   * `billResult` 필드와 관련된 코드 제거 (`billResult`는 더 이상 이 클래스에서 관리하지 않음).

3. **`BillFacade` 수정:**

   * `BillTimelineService`와 관련된 코드 제거.
   * `getBillByBillId` 메서드에서 `billResult` 값을 직접 설정하는 코드 삭제.
   * `billResult`는 BillService에서 가져오므로 불필요한 코드 간소화.

4. **불필요한 import 정리:**

   * 사용하지 않는 import 문 제거 및 코드 정리.

---

### 주요 의도:

* `billResult`와 관련된 책임을 `BillDetailInfo`로 이동하여 클래스 간의 역할 분리와 간결성 확보.
* 불필요한 서비스 호출을 제거하여 퍼포먼스 개선과 코드 유지보수성을 높임.

---

### 개선점:

1. **책임 분리:**

   * `BillInfoDto`와 `BillDetailInfo`의 역할이 더 명확해짐.
   * `BillFacade`에서 DTO를 직접 수정하던 로직을 제거하여 코드의 응집력 강화.

2. **퍼포먼스 향상:**

   * `billResult`를 가져오기 위한 추가적인 서비스 호출 제거로 응답 속도 향상.

3. **코드 간결화:**

   * 불필요한 코드와 import 문을 제거하여 가독성을 높임.

---

### 추가적인 제안:

1. **테스트 케이스 업데이트:**

   * 변경된 `BillDetailInfo`와 `BillFacade`의 로직에 대해 단위 테스트 및 통합 테스트를 업데이트.
   * `billResult` 관련 데이터가 올바르게 매핑되고 반환되는지 검증 필요.

2. **에러 처리 강화:**

   * `billResult`가 Bill 엔티티에서 누락된 경우 처리 로직 추가.
