### PR TITLE
redis repositories enabled off

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/config/RedisConfig.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/config/RedisConfig.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -37,6 +37,7 @@ db-connection-pool.db-name = ${DB_NAME}
 spring.data.redis.host=${ELASTIC_CACHE_HOST}
 spring.data.redis.password=${ELASTIC_CACHE_PASSWORD}
 spring.data.redis.port=6379
+spring.data.redis.repositories.enabled=false
 
 # Redirect_URI To Client
 app.oauth2.client-redirect-uri = http://localhost:3000/,https://lawdigest.net/,https://localhost.lawdigest.net:3000,http://localhost.lawdigest.net:3000


### PR DESCRIPTION
Spring Data Redis - Could not safely identify store assignment for repository candidate interface io.github.lahuman.domain.tip.ContentRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository

해당 내용 제거