### PR TITLE
Feat(#Social-Login-Naver) 네이버 소셜로그인 연동

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -75,7 +75,6 @@ jobs:
              -e "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
              -e "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" \
              -e "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" \
-             -e "KAKAO_USER_NAME_ATTRIBUTE=${{ secrets.KAKAO_USER_NAME_ATTRIBUTE }}" \
              -e "ACCESS_TOKEN_EXPIRY=${{ secrets.ACCESS_TOKEN_EXPIRY }}" \
              -e "REFRESH_TOKEN_EXPIRY=${{ secrets.REFRESH_TOKEN_EXPIRY }}" \
              -e "TOKEN_SECRET=${{ secrets.TOKEN_SECRET }}" \
@@ -86,6 +85,8 @@ jobs:
              -e "APP_ADMIN_KEY=${{ secrets.APP_ADMIN_KEY }}" \
              -e "ELASTIC_CACHE_HOST=${{ secrets.ELASTIC_CACHE_HOST }}" \
              -e "ELASTIC_CACHE_PASSWORD=${{ secrets.ELASTIC_CACHE_PASSWORD }}" \
+             -e "NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }}" \
+             -e "NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }}" \
             ${{ secrets.DOCKER_USERNAME }}/lawmaking-back
             docker rmi -f $(docker images -f "dangling=true" -q) || true
           

--- a/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Provider.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/domain/entity/Provider.java
@@ -1,5 +1,5 @@
 package com.everyones.lawmaking.domain.entity;
 
 public enum Provider {
-    KAKAO
+    KAKAO, NAVER
 }

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/auth/socialInfo/NaverOAuth2UserInfo.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/auth/socialInfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,38 @@
+package com.everyones.lawmaking.global.auth.socialInfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+
+    @Override
+    public String getId() {
+        return getProperty("id");
+    }
+
+    @Override
+    public String getName() {
+        return getProperty("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return getProperty("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return getProperty("profile_image");
+    }
+
+    private String getProperty(String key) {
+        var response = (Map<String, Object>) attributes.get("response");
+        return String.valueOf(response.get(key));
+    }
+}

--- a/lawmaking/src/main/java/com/everyones/lawmaking/global/auth/socialInfo/OAuth2UserInfoFactory.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/global/auth/socialInfo/OAuth2UserInfoFactory.java
@@ -7,12 +7,15 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.everyones.lawmaking.domain.entity.Provider.KAKAO;
+import static com.everyones.lawmaking.domain.entity.Provider.NAVER;
 
 @Slf4j
 public class OAuth2UserInfoFactory {
     public static OAuth2UserInfo getOAuth2UserInfo(Provider provider, Map<String, Object> attributes) {
         if (Objects.requireNonNull(provider) == KAKAO) {
             return new KakaoOAuth2UserInfo(attributes);
+        } else if (Objects.requireNonNull(provider) == NAVER) {
+            return new NaverOAuth2UserInfo(attributes);
         }
         throw new IllegalArgumentException("유효하지 않은 Provider Type 입니다.");
     }

--- a/lawmaking/src/main/resources/application-local.properties
+++ b/lawmaking/src/main/resources/application-local.properties
@@ -11,6 +11,8 @@ spring.jpa.generate-ddl=false
 #Kakao
 spring.security.oauth2.client.registration.kakao.redirect-uri = http://localhost:8080/v1/login/oauth2/code/kakao
 
+#Naver
+spring.security.oauth2.client.registration.naver.redirect-uri = http://localhost:8080/v1/login/oauth2/code/naver
 #Cookie
 app.auth.cookie-domain = localhost
 logging.level.org.hibernate.orm.jdbc.bind = trace

--- a/lawmaking/src/main/resources/application-prod.properties
+++ b/lawmaking/src/main/resources/application-prod.properties
@@ -13,5 +13,7 @@ spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 #Kakao
 spring.security.oauth2.client.registration.kakao.redirect-uri = https://api.lawdigest.net/v1/login/oauth2/code/kakao
 
+#Naver
+spring.security.oauth2.client.registration.naver.redirect-uri = https://api.lawdigest.net/v1/login/oauth2/code/naver
 #Cookie
 app.auth.cookie-domain = .lawdigest.net

--- a/lawmaking/src/main/resources/application.properties
+++ b/lawmaking/src/main/resources/application.properties
@@ -64,3 +64,16 @@ spring.security.oauth2.client.provider.kakao.token-uri = https://kauth.kakao.com
 spring.security.oauth2.client.provider.kakao.user-info-uri = https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute = id
 
+#Naver Config
+spring.security.oauth2.client.registration.naver.client-id = ${NAVER_CLIENT_ID}
+spring.security.oauth2.client.registration.naver.client-secret = ${NAVER_CLIENT_SECRET}
+spring.security.oauth2.client.registration.naver.scope = profile_nickname, account_email, profile_image
+spring.security.oauth2.client.registration.naver.client-name = NAVER
+spring.security.oauth2.client.registration.naver.authorization-grant-type = authorization_code
+spring.security.oauth2.client.registration.naver.client-authentication-method = client_secret_post
+
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response
+


### PR DESCRIPTION
### 변경사항 요약:

#### 1. **네이버 OAuth2 지원 추가**

* **환경설정**

  * `application.properties`, `application-local.properties`, `application-prod.properties`에 네이버 OAuth2 설정 추가.
  * 관련 속성(`client-id`, `client-secret`, `redirect-uri`, `scope` 등) 정의.

* **시크릿 관리**

  * `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET` 환경변수 추가.

* **`Provider` Enum 수정**

  * 기존 `KAKAO`에 `NAVER` 항목 추가.

* **`OAuth2UserInfo` 구현**

  * `NaverOAuth2UserInfo` 클래스 추가.

    * `id`, `nickname`, `email`, `profile_image` 정보를 가져오는 메서드 구현.
  * `OAuth2UserInfoFactory`에서 `NAVER`에 대한 분기 로직 추가.

---

#### 2. **GitHub Actions 배포 스크립트 업데이트**

* Docker 실행 시 `NAVER_CLIENT_ID` 및 `NAVER_CLIENT_SECRET` 환경 변수 추가.
* 기존 `KAKAO_USER_NAME_ATTRIBUTE` 환경 변수 제거.

---

#### 3. **Redirect URI 설정 추가**

* 로컬 및 프로덕션 환경의 네이버 OAuth2 리다이렉트 URI 정의.

---

### 주요 의도:

* 카카오와 함께 네이버 계정을 활용한 OAuth2 인증 지원.
* 새로운 인증 옵션을 제공해 사용자 접근성을 높임.

---

### 개선점:

1. **확장성**

   * 인증 제공자를 추가할 때 확장성 높은 구조 유지.

2. **보안성**

   * 민감한 정보(`client-id`, `client-secret`)는 시크릿 관리로 보안 강화.

3. **사용자 편의성**

   * 네이버 OAuth2를 통한 로그인 기능으로 다양한 플랫폼 사용자 확보.

---

### 테스트 및 추가 작업:

1. **OAuth2 연동 테스트**

   * 네이버 인증 흐름과 정보 매핑 정상 작동 확인.

2. **프런트엔드 연동 업데이트**

   * 네이버 로그인 버튼 추가 및 인증 처리.

3. **로그 및 에러 처리**

   * 네이버 API 연동 중 발생 가능한 에러 처리 로직 확인 및 로그 기록.

추가 요청 사항이 있으면 알려주세요!
