### PR TITLE
Fix(#proposers-null) 메인피드 조회시 representproposers 및 billproposers null 대신 빈 리스트 반환하도록 처리

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/bill/BillDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/bill/BillDto.java
@@ -7,6 +7,8 @@ import com.everyones.lawmaking.common.dto.proposer.RepresentativeProposerDto;
 import com.everyones.lawmaking.domain.entity.Bill;
 import com.everyones.lawmaking.domain.entity.BillProposer;
 import com.everyones.lawmaking.domain.entity.RepresentativeProposer;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
@@ -29,9 +31,11 @@ public class BillDto {
     private BillInfoDto billInfoDto;
 
     @NotNull
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<RepresentativeProposerDto> representativeProposerDtoList;
 
     @NotNull
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<PublicProposerDto> publicProposerDtoList;
 
     @NotNull

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.everyones.lawmaking.global.util.PaginationUtil;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,8 +138,8 @@ public class BillRepositoryImpl implements BillRepositoryCustom {
         return pagedBills.stream()
                 .map(bill -> BillDto.of(
                         bill,
-                        representativeProposerMap.get(bill.getBillId()),
-                        publicProposerMap.get(bill.getBillId()),
+                        representativeProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
+                        publicProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
                         billLikeMap.getOrDefault(bill.getBillId(), false)
                 ))
                 .toList();


### PR DESCRIPTION
커밋에서 수정된 내용을 정리하면 다음과 같습니다:

---

### 1. **`BillDto.java` 변경 사항**

* **Jackson 애노테이션 추가**

  * `@JsonSetter(nulls = Nulls.AS_EMPTY)` 추가됨.
  * 대상 필드:

    * `representativeProposerDtoList`
    * `publicProposerDtoList`
* **의미**: JSON 역직렬화 시 `null` 값이 들어오면 `null` 대신 **빈 리스트(`[]`)** 로 처리되도록 변경됨.
  → NPE 방지 및 일관된 응답 구조 보장.

---

### 2. **`BillRepositoryImpl.java` 변경 사항**

* **`Collections` import 추가**

  ```java
  import java.util.Collections;
  ```
* **`map()` 내부에서 리스트 매핑 시 변경**

  * 기존:

    ```java
    representativeProposerMap.get(bill.getBillId()),
    publicProposerMap.get(bill.getBillId()),
    ```
  * 변경 후:

    ```java
    representativeProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
    publicProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
    ```
* **의미**: `Map` 조회 시 값이 없을 경우 `null` 대신 **빈 리스트 반환** → NullPointerException 방지.

