### PR TITLE
Fix(#proposers-null) 메인피드 조회시 representproposers 및 billproposers null…

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/bill/BillDto.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/common/dto/bill/BillDto.java
@@ -7,6 +7,7 @@ import com.everyones.lawmaking.common.dto.proposer.RepresentativeProposerDto;
 import com.everyones.lawmaking.domain.entity.Bill;
 import com.everyones.lawmaking.domain.entity.BillProposer;
 import com.everyones.lawmaking.domain.entity.RepresentativeProposer;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;

--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.everyones.lawmaking.global.util.PaginationUtil;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,8 +138,8 @@ public class BillRepositoryImpl implements BillRepositoryCustom {
         return pagedBills.stream()
                 .map(bill -> BillDto.of(
                         bill,
-                        representativeProposerMap.get(bill.getBillId()),
-                        publicProposerMap.get(bill.getBillId()),
+                        representativeProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
+                        publicProposerMap.getOrDefault(bill.getBillId(), Collections.emptyList()),
                         billLikeMap.getOrDefault(bill.getBillId(), false)
                 ))
                 .toList();


### PR DESCRIPTION
… 대신 빈 리스트 반환하도록 처리 (#442)

* 메인피드 null 방지 적용

* jackson Null.asEmpty 제거