### PR TITLE
법안 검색 쿼리 수정

### DIFF
--- a/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
+++ b/lawmaking/src/main/java/com/everyones/lawmaking/repository/BillRepository.java
@@ -100,17 +100,14 @@ public interface BillRepository extends JpaRepository<Bill, String>, BillReposit
             "AND b.id != :billId ")
     List<Bill> findSimilarBills(@Param("billName") String billName, @Param("billId") String billId);
 
-    @Query(value = "select bill_id\n" +
-            "from\n" +
-            "(select bill_id, propose_date, match(bill_name) against(concat('*',:keyword,'*') in boolean mode) as bill_name_rel,\n" +
-            "match(brief_summary) against(concat('*',:keyword,'*') in boolean mode) as brief_summary_rel,\n" +
-            "match(gpt_summary) against(concat('*',:keyword,'*') in boolean mode) as gpt_summary_rel,\n" +
-            "match(summary) against(concat('*',:keyword,'*') in boolean mode) as summary_rel\n" +
-            "from Bill) search\n" +
-            "where bill_name_rel >0 or brief_summary_rel>0 or gpt_summary_rel>0 or summary_rel > 0\n" +
-            "order by propose_date desc, bill_name_rel desc, brief_summary_rel desc, gpt_summary_rel desc, summary_rel desc ;"
-            , nativeQuery = true)
-    Slice<String> findBillByKeyword(Pageable pageable,@Param("keyword") String keyword);
+    @Query(value = "SELECT bill_id " +
+            "FROM Bill " +
+            "WHERE MATCH(brief_summary, gpt_summary) AGAINST(:keyword IN BOOLEAN MODE) " +
+            "ORDER BY propose_date DESC, " +
+            "         MATCH(brief_summary, gpt_summary) AGAINST(:keyword IN BOOLEAN MODE) DESC",
+            nativeQuery = true)
+    Slice<String> findBillByKeyword(Pageable pageable, @Param("keyword") String keyword);
+
 
 
 


### PR DESCRIPTION
# PR 제목
서브쿼리 제거 및 FULLTEXT 검색 단순화 (ngram 기반 검색 적용)

---

### 변경 요약
- 기존에는 **MySQL 기본 파서(공백 단위 토큰화)**를 사용하여 `MATCH…AGAINST` 검색을 수행했습니다.  
- 이번 변경에서는 **ngram 파서 기반 FULLTEXT 인덱스**를 도입하여 한국어 단어 단위 검색 품질을 개선했습니다.  
- **서브쿼리 제거** 후 `brief_summary`, `gpt_summary`에 대해 단일 `MATCH…AGAINST`로 단순화하였습니다.  
- 정렬은 **제안일자(propose_date) 내림차순** → **관련도 점수 내림차순**으로 명확히 했습니다.  

---

### 변경 이유

#### 1. 기존 기본 파서 한계
- MySQL 기본 FULLTEXT 파서는 **공백 단위 토큰화**를 수행합니다.  
- 한국어 `"소방청"`은 하나의 토큰으로 저장되므로 `"소방"`만 검색하면 매칭되지 않았습니다.  
- 또한 `concat('*', :keyword, '*')` 구문은 FULLTEXT에서 지원되지 않아 **풀스캔**이 발생했습니다.  

#### 2. ngram 파서 적용
- **ngram 기반 인덱스**를 생성하면 `"소방청"`이 `"소방"`, `"방청"` 등 부분 단위로 토큰화됩니다.  
- 결과적으로 `"소방"` 검색 시 `"소방청"`과 매칭이 가능합니다.  
- `innodb_ft_min_token_size`(기본 3)를 낮추거나 `ngram_token_size`(기본 2)를 조정하여 세밀한 검색 품질 확보가 가능합니다.  

#### 3. 쿼리 단순화 및 성능 개선
- 불필요한 **서브쿼리 제거**로 CPU 사용과 임시 테이블 생성을 줄였습니다.  
- 단일 `MATCH`로 **FULLTEXT 인덱스 활용**이 가능해져 검색 속도가 개선되었습니다.  

테스트 결과
Before

-> Table scan on Bill (rows=34,267, actual=0.2..120ms)
-> Filter 후 결과 431 rows (actual=1.62..137ms)
-> Sort (actual=140..144ms)
총 실행 시간: 약 144ms+

After

-> Full-text index search on idx_brief_gpt (rows=373, actual=0.296..6.64ms)
-> Filter 결과 373 rows (0.308..6.7ms)
-> Sort (9.15..9.66ms)
총 실행 시간: 약 26ms


